### PR TITLE
Backport #214 to current

### DIFF
--- a/pages/k8s/cni-calico.md
+++ b/pages/k8s/cni-calico.md
@@ -61,7 +61,7 @@ that would apply to `charmed-kubernetes` to this bundle also.
 ## Calico configuration options
 
 | Name                |  Type  |  Default value                           | Description                                                    |
-|=====================|========|==========================================|================================================================|
+|---------------------|--------|------------------------------------------|----------------------------------------------------------------|
 | calico-node-image   | string | docker.io/calico/node:v3.6.1             | The image id to use for calico/node                            |
 | calico-policy-image | string | docker.io/calico/kube-controllers:v3.6.1 | The image id to use for calico/kube-controllers                |
 | ipip                | string | Never                                    | IPIP mode. Must be one of "Always", "CrossSubnet", or "Never". |

--- a/pages/k8s/cni-canal.md
+++ b/pages/k8s/cni-canal.md
@@ -36,7 +36,7 @@ that would apply to `charmed-kubernetes` to this bundle also.
 ## Canal configuration options
 
 |Name                  | Type    | Default   | Description                      |
-|======================|=========|===========|==================================|
+|----------------------|---------|-----------|----------------------------------|
 | calico-node-image    | string  | docker.io/calico/node:v3.6.1|The image id to use for calico/node. |
 | calico-policy-image  | string  | docker.io/calico/kube-controllers:v3.6.1|The image id to use for calico/kube-controllers. |
 | cidr                 | string  | 10.1.0.0/16|Network CIDR to assign to Flannel |

--- a/pages/k8s/cni-flannel.md
+++ b/pages/k8s/cni-flannel.md
@@ -31,7 +31,7 @@ flannel will be used for CNI.
 
 
 | Name                  |  Type     |  Default value | Description  |
-|=============|=======|============|====================================|
+|-----------------------|-----------|----------------|--------------|
 | cidr                       | string     | 10.1.0.0/16      | Network CIDR to assign to Flannel  |
 | iface                      | string     | see description>  |  The interface to bind flannel overlay networking. The default value is the interface bound to the CNI endpoint. |
 |  nagios_context |  string |  juju  |  A string that will be prepended to instance name to set the host name in nagios. If you're running multiple environments with the same services in them this allows you to differentiate between them. Used by the nrpe subordinate charm. |


### PR DESCRIPTION
This pull request has been generated by the canonical-doc-utilities backport command.

It has successfully cherry-picked individual commits from a different branch of this repository, which should merge without issue. It is advisable to check the changes only occur where you expect them!

The original PR this was ported from can be viewed here:https://github.com/charmed-kubernetes/kubernetes-docs/pull/214