### PR TITLE
Backport #216 to current

### DIFF
--- a/pages/k8s/container-runtime.md
+++ b/pages/k8s/container-runtime.md
@@ -27,7 +27,7 @@ of **Charmed Kubernetes**.
 Settings which require additional explanation are described below.
 
 |Name             |   Type         |  Default Value                              |  Description                           |
-|==========|=========|========================|=====================|
+|-----------------|----------------|---------------------------------------------|--------------|
 | custom_registries:   |  json |  '[]' |  Setting this config allows images to be pulled from registries requiring auth. [See below](#custom-registries).  |
 |enable-cgroups   | bool   | False   |   WARNING changing this option will reboot the host - [see notes](#enable-cgroups).|
 |extra-packages | string  | ""  | Space separated list of extra deb packages to install.  |


### PR DESCRIPTION
This pull request has been generated by the canonical-doc-utilities backport command.

It has successfully cherry-picked individual commits from a different branch of this repository, which should merge without issue. It is advisable to check the changes only occur where you expect them!

The original PR this was ported from can be viewed here:https://github.com/charmed-kubernetes/kubernetes-docs/pull/216