### PR TITLE
Backport #218 to current

### DIFF
--- a/pages/k8s/release-notes.md
+++ b/pages/k8s/release-notes.md
@@ -101,6 +101,8 @@ Users relying on `docker-registry` to serve container images to Kubernetes deplo
 continue to use the Docker subordinate runtime as outlined in the [upgrade notes](/kubernetes/docs/upgrade-notes#1.15),
 under the heading "To keep Docker as the container runtime".
 
+- Containerd charm does not work on LXD ([bug 1834524](https://bugs.launchpad.net/charm-containerd/+bug/1834524))
+
 
 # 1.14 Bugfix release
 

--- a/pages/k8s/release-notes.md
+++ b/pages/k8s/release-notes.md
@@ -103,6 +103,11 @@ under the heading "To keep Docker as the container runtime".
 
 - Containerd charm does not work on LXD ([bug 1834524](https://bugs.launchpad.net/charm-containerd/+bug/1834524))
 
+We intend to fix this shortly after release. For now, if you want to deploy
+Charmed Kubernetes on LXD, we recommend using the Docker subordinate charm
+instead. Instructions for this can be found in the
+[Container runtimes][container-runtime] section of our documentation.
+
 
 # 1.14 Bugfix release
 
@@ -274,3 +279,4 @@ Please see [this page][historic] for release notes of earlier versions.
 [hacluster-docs]: /kubernetes/docs/hacluster
 [cni-calico]: /kubernetes/docs/cni-calico
 [containerd]: /kubernetes/docs/containerd
+[container-runtime]: /kubernetes/docs/container-runtime


### PR DESCRIPTION
This pull request has been generated by the canonical-doc-utilities backport command.

It has successfully cherry-picked individual commits from a different branch of this repository, which should merge without issue. It is advisable to check the changes only occur where you expect them!

The original PR this was ported from can be viewed here:https://github.com/charmed-kubernetes/kubernetes-docs/pull/218