### PR TITLE
Deploy easyrsa as a prerequisite for restore

### DIFF
--- a/pages/k8s/backups.md
+++ b/pages/k8s/backups.md
@@ -80,7 +80,6 @@ As restoring only works when there is a single unit of **etcd**, it is usual to 
 ```bash
 juju deploy etcd new-etcd --series=bionic
 juju deploy cs:~containers/easyrsa new-easyrsa --series=bionic
-
 juju add-relation new-etcd:certificates new-easyrsa:client
 ```
 

--- a/pages/k8s/backups.md
+++ b/pages/k8s/backups.md
@@ -79,6 +79,9 @@ As restoring only works when there is a single unit of **etcd**, it is usual to 
 
 ```bash
 juju deploy etcd new-etcd --series=bionic
+juju deploy cs:~containers/easyrsa new-easyrsa --series=bionic
+
+juju add-relation new-etcd:certificates new-easyrsa:client
 ```
 
 The `--series` option is included here to illustrate how to specify which series the new unit should be running on.


### PR DESCRIPTION
Otherwise the subsequent restore action will fail with:
FileNotFoundError: [Errno 2] No such file or directory:
'/var/snap/etcd/common/etcd.conf.yml'
Because "new-etcd" is not bootstrapped yet since no CA is available.

Naming easyrsa as "new-easyrsa" is necessary since new-etcd will be
stuck if an existing easyrsa is used. The issue is tracked as
LP: #1835056 (https://launchpad.net/bugs/1835056)