### PR TITLE
Specifying etcd channel is necessary

### DIFF
--- a/pages/k8s/backups.md
+++ b/pages/k8s/backups.md
@@ -78,12 +78,13 @@ Restoring a snapshot should not be performed when there is more than one unit of
 As restoring only works when there is a single unit of **etcd**, it is usual to deploy a new instance of the application first.
 
 ```bash
-juju deploy etcd new-etcd --series=bionic
+juju deploy etcd new-etcd --series=bionic --config channel=3.2/stable
 juju deploy cs:~containers/easyrsa new-easyrsa --series=bionic
 juju add-relation new-etcd:certificates new-easyrsa:client
 ```
 
 The `--series` option is included here to illustrate how to specify which series the new unit should be running on.
+The `--config` option is required to specify the same channel of etcd as the original unit.
 
 Next we upload and identify the snapshot file to this new unit:
 


### PR DESCRIPTION
As described in LP: #1826009 (https://launchpad.net/bugs/1826009), the
default channel in etcd charm is 2.3/stable. However, Kubernetes bundle
uses 3.2/stable as of today instead so manually specifying the channel
is important to have the same version of etcd as the previous cluster.