### PR TITLE
Fix CK 1.15 bundle rev and date

### DIFF
--- a/pages/k8s/install-manual.md
+++ b/pages/k8s/install-manual.md
@@ -232,7 +232,7 @@ versions of the **Charmed Kubernetes** bundle are shown in the table below:
 
 | Kubernetes version | Charmed Kubernetes bundle |
 | --- | --- |
-| 1.15.x         | [charmed-kubernetes-139](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-139/archive/bundle.yaml) |
+| 1.15.x         | [charmed-kubernetes-142](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-142/archive/bundle.yaml) |
 | 1.14.x         | [charmed-kubernetes-124](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-124/archive/bundle.yaml) |
 | 1.13.x         | [canonical-kubernetes-435](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-435/archive/bundle.yaml?channel=stable) |
 | 1.12.x         | [canonical-kubernetes-357](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-357/archive/bundle.yaml?channel=stable) |

--- a/pages/k8s/release-notes.md
+++ b/pages/k8s/release-notes.md
@@ -16,7 +16,7 @@ toc: False
 
 # 1.15
 
-### June 26, 2019 -  [charmed-kubernetes-139](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-139/archive/bundle.yaml)
+### June 28, 2019 -  [charmed-kubernetes-142](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-142/archive/bundle.yaml)
 
 ## What's new
 


### PR DESCRIPTION
@tvansteenburgh noticed that the revision of charmed-kubernetes in stable does not match the docs. Here's a quick fix.

Based on IRC logs:
1. We didn't release CK 1.15 to stable until June 28th.
2. Within a few hours of releasing charmed-kubernetes-139, we released charmed-kubernetes-142 which fixed a minor problem where bundle revisions didn't 100% match charm revisions in stable.