### PR TITLE
Adding comment about Kubernetes dashboard

### DIFF
--- a/pages/k8s/release-notes.md
+++ b/pages/k8s/release-notes.md
@@ -78,7 +78,7 @@ Special thanks to [pierrop](https://github.com/pierrop) for contributing a fix t
 
 ## Known Issues
 
-The Kubernetes Dashboard for 1.16 is currently in beta. The last stable dashboard no longer works with Kubernetes 1.16.
+The Kubernetes Dashboard shipped with Charmed Kubernetes 1.16 is version 2.0.0-beta4. While unusual to ship a beta component with a stable release, in this case it was necessary, since the latest stable dashboard (v1.10.1) does not work with Kubernetes 1.16.
 
 # 1.15+ck1 Bugfix release
 

--- a/pages/k8s/release-notes.md
+++ b/pages/k8s/release-notes.md
@@ -76,6 +76,10 @@ A list of bug fixes and other minor feature updates in this release can be found
 Special thanks to [pierrop](https://github.com/pierrop) for contributing a fix to
 [issue 1841965](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1841965)!
 
+## Known Issues
+
+The Kubernetes Dashboard for 1.16 is currently in beta. The last stable dashboard no longer works with Kubernetes 1.16.
+
 # 1.15+ck1 Bugfix release
 
 ### August 15, 2019 - [charmed-kubernetes-209](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-209/archive/bundle.yaml)


### PR DESCRIPTION
Tim suggested that we point out that the Kubernetes dashboard is moving from stable to a beta out of necessity, but this isn't called out anywhere. He suggested an addition in the release notes to point out that it is known to be a beta product and users should expect beta behavior.