### PR TITLE
Clean up instructions for Vault HA

### DIFF
--- a/pages/k8s/using-vault.md
+++ b/pages/k8s/using-vault.md
@@ -183,29 +183,46 @@ to the `options` section of `vault` in the overlay above:
 
 ## Using Vault with HA
 
-To enable HA for **Vault**, you will need to first bring up the deployment with
-**Vault** in non-HA mode using the instructions above, waiting for everything
-to settle, and then transitioning **Vault** to HA mode. This is necessary
-because **Vault** requires **etcd** to be running to enter HA mode, but
-**etcd** requires PKI certificates to get up and running, leading to a
-chicken-and-egg conflict.
+**Vault** also supports HA mode by adding a second unit and a relation to Etcd.
+To deploy with this configuration, you can use the following overlay
+([download][vault-pki-ha-yaml]) instead with the instructions from above to
+deploy, init, and unseal Vault:
 
-Once the deployment is up and settled according to the instructions above,
-with **Vault** unsealed and everything functioning, you can then transition
-**Vault** to HA mode with the following commands:
-
-```bash
-juju add-relation vault:etcd etcd
-juju add-unit vault
+```yaml
+applications:
+  easyrsa: null
+  vault:
+    charm: cs:~openstack-charmers-next/vault
+    num_units: 2
+    options:
+      auto-generate-root-ca-cert: true
+  percona-cluster:
+    charm: cs:percona-cluster
+    num_units: 1
+relations:
+- - kubernetes-master:certificates
+  - vault:certificates
+- - etcd:certificates
+  - vault:certificates
+- - kubernetes-worker:certificates
+  - vault:certificates
+- - vault:shared-db
+  - percona-cluster:shared-db
+- - vault:etcd
+  - etcd:db
 ```
 
-Once the second unit of **Vault** is up, you will also need to unseal it
-using the same instructions above with any three of the five unseal keys
-and the root token you generated previously.
+<div class="p-notification--information">
+  <p markdown="1" class="p-notification__response">
+    You will only need to perform the `vault init` step once, but you will
+    need to unseal each unit individually.
+  </p>
+</div>
 
 
 <!-- LINKS -->
 [vault-pki-yaml]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/overlays/vault-pki-overlay.yaml
+[vault-pki-ha-yaml]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/overlays/vault-pki-ha-overlay.yaml
 [certs-doc]: /kubernetes/docs/certs-and-trust
 [encryption-doc]: /kubernetes/docs/encryption-at-rest
 [vault]: https://www.vaultproject.io

--- a/pages/k8s/using-vault.md
+++ b/pages/k8s/using-vault.md
@@ -56,10 +56,10 @@ relations:
   - percona-cluster:shared-db
 ```
 
-Save this to a file named `k8s-vault.yaml` and deploy with:
+Save this to a file named `vault-pki-overlay.yaml` and deploy with:
 
 ```bash
-juju deploy charmed-kubernetes --overlay ./k8s-vault.yaml
+juju deploy charmed-kubernetes --overlay ./vault-pki-overlay.yaml
 ```
 
 Once the deployment settles, you will notice that several applications are in a


### PR DESCRIPTION
From testing, the manual non-HA-to-HA transition steps are not necessary, so this cleans them up in favor of an overlay.

Depends on: https://github.com/charmed-kubernetes/bundle/pull/755