### PR TITLE
add graylog logging section

### DIFF
--- a/assets/graylog-vhost.tmpl
+++ b/assets/graylog-vhost.tmpl
@@ -1,0 +1,5 @@
+<Location "/">
+    RequestHeader set X-Graylog-Server-URL "http://{{servername}}/"
+    ProxyPass http://{{graylog_web}}/
+    ProxyPassReverse http://{{graylog_web}}/
+</Location>

--- a/pages/k8s/logging.md
+++ b/pages/k8s/logging.md
@@ -148,7 +148,9 @@ The logging level can be set like this:
 <div class="p-notification--caution">
   <p markdown="1" class="p-notification__response">
     <span class="p-notification__status">Caution!</span>
-    It isn't a good idea to leave the logging level at 'TRACE' for any longer than you actually need to. Verbose logging not only consumes network bandwidth but also fills up the database on the controller.
+    It isn't a good idea to leave the logging level at 'TRACE' for any longer than
+    you actually need to. Verbose logging not only consumes network bandwidth but
+    also fills up the database on the controller.
   </p>
 </div>
 
@@ -263,23 +265,29 @@ juju run-action --wait graylog/0 show-admin-password
 ```
 
 Browse to `http://<your-apache2-ip>` and login with `admin` as the username
-and `<your-graylog-password>` as the password. Note: if the interface is not
-immediately available, please wait as the reverse proxy configuration may take
-up to 5 minutes to complete.
+and `<your-graylog-password>` as the password. 
+
+<div class="p-notification--information">
+  <p markdown="1" class="p-notification__response">
+    <span class="p-notification__status">Note:</span>
+    If the interface is not immediately available, please wait as the reverse
+    proxy configuration may take up to 5 minutes to complete.
+  </p>
+</div>
 
 Once logged in, head to the `Sources` tab to get an overview of the logs
 collected from our K8s master and workers:
 
-![Screen Shot 2019-06-13 at 9 31 54 AM](https://user-images.githubusercontent.com/4576822/59441924-ee21b580-8dbe-11e9-84bd-07676bf2d61f.png)
+![Screen Shot of graylog](https://assets.ubuntu.com/v1/5b8c576e-graylog-1.png)
 
 Drill into those logs by clicking the `System / Inputs` tab and selecting
 `Show received messages` for the filebeat input:
 
-![Screen Shot 2019-06-13 at 9 39 20 AM](https://user-images.githubusercontent.com/4576822/59442102-3214ba80-8dbf-11e9-8f63-34da997bfb52.png)
+![Screen Shot of graylog](https://assets.ubuntu.com/v1/ee6de56c-graylog-2.png)
 
 From here, you may want to explore various filters or setup Graylog dashboards
 to help identify the events that are most important to you. Check out the
-[Graylog Dashboard docs][graylog-dashboards] for details on customizing your
+[Graylog Dashboard docs][graylog-dashboards] for details on customising your
 view.
 
 <!--LINKS -->

--- a/pages/k8s/monitoring.md
+++ b/pages/k8s/monitoring.md
@@ -168,56 +168,11 @@ juju config nrpe nagios_master=<ip-address-of-nagios>
 
 See the [External Nagios][external-nagios] section of the NRPE charm readme for more information.
 
-## Monitoring with **Elasticsearch**
-
-Elasticsearch ([https://www.elastic.co/][elastic]) is a popular monitoring application which
-can be used in conjunction with **Charmed Kubernetes**.
-
-### Deploy the required applications
-
-Use Juju to deploy the required applications:
-
-```bash
-juju deploy elasticsearch --series=bionic --constraints "mem=4G root-disk=16G"
-juju deploy filebeat --series=bionic
-juju deploy kibana --series=xenial
-juju expose kibana
-```
-
-### Add relations
-
-You now need to relate the elasticsearch applications together, and connect the `filebeat` application to the applications you want to monitor:
-
-```bash
-juju add-relation elasticsearch kibana
-juju add-relation elasticsearch filebeat
-
-juju add-relation filebeat kubernetes-master
-juju add-relation filebeat kubernetes-worker
-juju add-relation filebeat kubeapi-load-balancer
-juju add-relation filebeat etcd
-```
-
-### Initialise the dashboard
-
-A sample dashboard is included in kibana for monitoring the beat services. You can deploy it by running the following:
-
-```
-juju run-action --wait kibana/0 load-dashboard dashboard=beats
-```
-
-You can find the dashboard at the public IP address of your **kibana** application
-
-```
-juju status kibana --format yaml| grep public-address
-```
-
 <!-- LINKS -->
 
 [monitoring-pgt-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/overlays/monitoring-pgt-overlay.yaml
 [quickstart]: /kubernetes/docs/quickstart
 [nagios]: https://www.nagios.org/
-[elastic]: https://www.elastic.co/
 [external-nagios]: https://jujucharms.com/nrpe/
 
 <!-- FEEDBACK -->


### PR DESCRIPTION
This is a redo of #199. Now that the graylog charm officially supports v3, we can get rid of the hacky deployment/config steps and document graylog deployment with an overlay.

Depends on https://github.com/charmed-kubernetes/bundle/pull/757