### PR TITLE
Update release-notes.md

### DIFF
--- a/pages/k8s/install-manual.md
+++ b/pages/k8s/install-manual.md
@@ -232,7 +232,7 @@ versions of the **Charmed Kubernetes** bundle are shown in the table below:
 
 | Kubernetes version | Charmed Kubernetes bundle |
 | --- | --- |
-| 1.16.x         | [charmed-kubernetes-252](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-252/archive/bundle.yaml) |
+| 1.16.x         | [charmed-kubernetes-270](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-252/archive/bundle.yaml) |
 | 1.15.x         | [charmed-kubernetes-209](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-209/archive/bundle.yaml) |
 | 1.14.x         | [charmed-kubernetes-124](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-124/archive/bundle.yaml) |
 | 1.13.x         | [canonical-kubernetes-435](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-435/archive/bundle.yaml?channel=stable) |

--- a/pages/k8s/release-notes.md
+++ b/pages/k8s/release-notes.md
@@ -15,7 +15,7 @@ toc: False
 
 # 1.16+ck1 Bugfix release
 
-### October 4, 2019 - [charmed-kubernetes-268](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-268/archive/bundle.yaml)
+### October 4, 2019 - [charmed-kubernetes-270](https://api.jujucharms.com/charmstore/v5/bundle/charmed-kubernetes-270/archive/bundle.yaml)
 
 ## Fixes
 


### PR DESCRIPTION
We had to re-spin the 1.16 bundles to pick up the correct snap channel for 1.16-ck1.  Charm revs didn't change, but the bundle rev itself did.