### PR TITLE
missed a revision update in the 1.16.x link

### DIFF
--- a/pages/k8s/install-manual.md
+++ b/pages/k8s/install-manual.md
@@ -232,7 +232,7 @@ versions of the **Charmed Kubernetes** bundle are shown in the table below:
 
 | Kubernetes version | Charmed Kubernetes bundle |
 | --- | --- |
-| 1.16.x         | [charmed-kubernetes-270](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-252/archive/bundle.yaml) |
+| 1.16.x         | [charmed-kubernetes-270](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-270/archive/bundle.yaml) |
 | 1.15.x         | [charmed-kubernetes-209](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-209/archive/bundle.yaml) |
 | 1.14.x         | [charmed-kubernetes-124](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-124/archive/bundle.yaml) |
 | 1.13.x         | [canonical-kubernetes-435](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-435/archive/bundle.yaml?channel=stable) |


### PR DESCRIPTION
@evilnick we got the link text right, but missed a `s/252/270` in the link itself.