### PR TITLE
add 1.16-ck2 release notes

### DIFF
--- a/pages/k8s/install-manual.md
+++ b/pages/k8s/install-manual.md
@@ -232,7 +232,7 @@ versions of the **Charmed Kubernetes** bundle are shown in the table below:
 
 | Kubernetes version | Charmed Kubernetes bundle |
 | --- | --- |
-| 1.16.x         | [charmed-kubernetes-270](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-270/archive/bundle.yaml) |
+| 1.16.x         | [charmed-kubernetes-316](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-316/archive/bundle.yaml) |
 | 1.15.x         | [charmed-kubernetes-209](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-209/archive/bundle.yaml) |
 | 1.14.x         | [charmed-kubernetes-124](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-124/archive/bundle.yaml) |
 | 1.13.x         | [canonical-kubernetes-435](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-435/archive/bundle.yaml?channel=stable) |

--- a/pages/k8s/release-notes.md
+++ b/pages/k8s/release-notes.md
@@ -13,6 +13,15 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+# 1.16+ck2 Bugfix release
+
+### November xx, 2019 - [charmed-kubernetes-xxx](https://api.jujucharms.com/charmstore/v5/bundle/charmed-kubernetes-xxx/archive/bundle.yaml)
+
+## Fixes
+
+A list of bug fixes and other minor feature updates in this release can be found at
+[https://launchpad.net/charmed-kubernetes/+milestone/1.16+ck2](https://launchpad.net/charmed-kubernetes/+milestone/1.16+ck2).
+
 # 1.16+ck1 Bugfix release
 
 ### October 4, 2019 - [charmed-kubernetes-270](https://api.jujucharms.com/charmstore/v5/bundle/charmed-kubernetes-270/archive/bundle.yaml)

--- a/pages/k8s/release-notes.md
+++ b/pages/k8s/release-notes.md
@@ -15,7 +15,7 @@ toc: False
 
 # 1.16+ck2 Bugfix release
 
-### November xx, 2019 - [charmed-kubernetes-xxx](https://api.jujucharms.com/charmstore/v5/bundle/charmed-kubernetes-xxx/archive/bundle.yaml)
+### November 22, 2019 - [charmed-kubernetes-316](https://api.jujucharms.com/charmstore/v5/bundle/charmed-kubernetes-316/archive/bundle.yaml)
 
 ## Fixes
 


### PR DESCRIPTION
Bugs fixed:

https://launchpad.net/charmed-kubernetes/+milestone/1.16+ck2

WIP until code merges are in stable -- just in case we need to call out more than a bug link.