### PR TITLE
Replaced trust step with --trust parameter

### DIFF
--- a/pages/k8s/aws-integration.md
+++ b/pages/k8s/aws-integration.md
@@ -49,13 +49,7 @@ relations:
 To use this overlay with the **Charmed Kubernetes** bundle, it is specified during deploy like this:
 
 ```bash
-juju deploy charmed-kubernetes  --overlay ~/path/aws-overlay.yaml
-```
-
-Then run the command to share credentials with this charm:
-
-```bash
-juju trust aws-integrator
+juju deploy charmed-kubernetes  --overlay ~/path/aws-overlay.yaml --trust
 ```
 
 ... and remember to fetch the configuration file!

--- a/pages/k8s/gcp-integration.md
+++ b/pages/k8s/gcp-integration.md
@@ -70,13 +70,7 @@ To use this overlay with the **Charmed Kubernetes** bundle, it is specified
 during deploy like this:
 
 ```bash
-juju deploy charmed-kubernetes --overlay ~/path/gcp-overlay.yaml
-```
-
-Then run the command to share credentials with this charm:
-
-```bash
-juju trust gcp-integrator
+juju deploy charmed-kubernetes --overlay ~/path/gcp-overlay.yaml --trust
 ```
 
 ... and remember to fetch the configuration file!

--- a/pages/k8s/openstack-integration.md
+++ b/pages/k8s/openstack-integration.md
@@ -77,13 +77,7 @@ have also been released.
 To use the overlay with the **Charmed Kubernetes** bundle, specify it during deploy like this:
 
 ```bash
-juju deploy charmed-kubernetes --overlay ~/path/openstack-overlay.yaml
-```
-
-Then run the command to share credentials with this charm:
-
-```bash
-juju trust openstack-integrator
+juju deploy charmed-kubernetes --overlay ~/path/openstack-overlay.yaml --trust
 ```
 
 ... and remember to fetch the configuration file!


### PR DESCRIPTION
Trying to 'juju deploy charmed-kubernetes  --overlay ~/aws-overlay.yaml' fails with:

ERROR Bundle cannot be deployed without trusting applications with your cloud credentials.
Please repeat the deploy command with the --trust argument if you consent to trust the following application(s):
  - aws-integrator