### PR TITLE
Mark loading keystone policy as optional

### DIFF
--- a/pages/k8s/ldap.md
+++ b/pages/k8s/ldap.md
@@ -253,14 +253,12 @@ juju config kubernetes-master authorization-mode="Node,RBAC"
 juju config kubernetes-master enable-keystone-authorization=true
 ```
 
- When authorisation is enabled, the policy is defined in the configuration. A new
- policy can be applied by running:
+ When authorisation is enabled, the [default policy defined in the configuration][policy] will be used.
+ Optionally, A custom policy can be applied by running:
 
 ```bash
 juju config kubernetes-master keystone-policy="$(cat policy.yaml)"
 ```
-
-The [default policy may be downloaded][policy] for easy editing.
 
 
 ## Custom Certificate Authority


### PR DESCRIPTION
The default policy is already there by the default charm config.
https://jaas.ai/u/containers/kubernetes-master#charm-config-keystone-policy
Mark the step of loading a custom policy as optional.