### PR TITLE
Add more info to CephFS doc

### DIFF
--- a/pages/k8s/storage.md
+++ b/pages/k8s/storage.md
@@ -69,6 +69,9 @@ juju deploy -n1 ceph-fs
 juju add-relation ceph-fs ceph-mon
 ```
 
+**Charmed Kubernetes** will then deploy the CephFS provisioner pod
+and create a `cephfs` storage class in the cluster.
+
 ### Relate to Charmed Kubernetes
 
 Making **Charmed Kubernetes** aware of your **Ceph** cluster requires 2 **Juju** relations.
@@ -141,22 +144,18 @@ kubectl get sc,po
 ... should return output similar to:
 
 ```no-highlight
-NAME                                             PROVISIONER     AGE
-storageclass.storage.k8s.io/ceph-ext4            csi-rbdplugin    7m
-storageclass.storage.k8s.io/ceph-fs              csi-cephfs       7m
-storageclass.storage.k8s.io/ceph-xfs (default)   csi-rbdplugin    7m
+NAME                                             PROVISIONER           RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
+storageclass.storage.k8s.io/ceph-ext4            rbd.csi.ceph.com      Delete          Immediate           false                  7m
+storageclass.storage.k8s.io/ceph-xfs (default)   rbd.csi.ceph.com      Delete          Immediate           false                  7m
+storageclass.storage.k8s.io/cephfs               cephfs.csi.ceph.com   Delete          Immediate           false                  7m
 
-NAME                                                   READY     STATUS    RESTARTS   AGE
-pod/csi-cephfsplugin-2ljt6                             2/2       Running   0          7m
-pod/csi-cephfsplugin-attacher-0                        1/1       Running   0          7m
-pod/csi-cephfsplugin-cm5lq                             2/2       Running   0          7m
-pod/csi-cephfsplugin-provisioner-0                     2/2       Running   0          7m
-pod/csi-cephfsplugin-v57df                             2/2       Running   0          7m
-pod/csi-rbdplugin-attacher-0                           1/1       Running   0          7m
-pod/csi-rbdplugin-cnh9k                                2/2       Running   0          7m
-pod/csi-rbdplugin-lr66m                                2/2       Running   0          7m
-pod/csi-rbdplugin-mnn94                                2/2       Running   0          7m
-pod/csi-rbdplugin-provisioner-0                        1/1       Running   0          7m
+NAME                                 READY   STATUS    RESTARTS   AGE
+pod/csi-cephfsplugin-attacher-0      1/1     Running   0          7m
+pod/csi-cephfsplugin-bzzgn           2/2     Running   0          7m
+pod/csi-cephfsplugin-provisioner-0   2/2     Running   0          7m
+pod/csi-rbdplugin-69xp6              2/2     Running   0          7m
+pod/csi-rbdplugin-attacher-0         1/1     Running   0          7m
+pod/csi-rbdplugin-provisioner-0      3/3     Running   0          7m
 ```
 
 Note that the CephFS storage class and pods will only be present if CephFS was included above.


### PR DESCRIPTION
This adds a bit more info regarding CephFS, calling out the storage class that is automatically added.  It also updates the example output to make it more accurate.