### PR TITLE
Add missing relations on snapshot restore

### DIFF
--- a/pages/k8s/backups.md
+++ b/pages/k8s/backups.md
@@ -104,6 +104,7 @@ Once the restore action has finished, you should see output confirming that the 
 
 ```bash
 juju add-relation new-etcd flannel
+juju add-relation new-etcd kubernetes-master
 juju add-relation kubeapi-load-balancer:certificates new-easyrsa:client
 juju add-relation kubernetes-master:certificates new-easyrsa:client
 juju add-relation kubernetes-worker:certificates new-easyrsa:client

--- a/pages/k8s/backups.md
+++ b/pages/k8s/backups.md
@@ -83,6 +83,9 @@ As restoring only works when there is a single unit of **etcd**, it is usual to 
 juju deploy etcd new-etcd --series=bionic --config channel=3.2/stable
 juju deploy cs:~containers/easyrsa new-easyrsa --series=bionic
 juju add-relation new-etcd:certificates new-easyrsa:client
+juju add-relation kubeapi-load-balancer:certificates new-easyrsa:client
+juju add-relation kubernetes-master:certificates new-easyrsa:client
+juju add-relation kubernetes-worker:certificates new-easyrsa:client
 ```
 
 The `--series` option is included here to illustrate how to specify which series the new unit should be running on.

--- a/pages/k8s/backups.md
+++ b/pages/k8s/backups.md
@@ -83,9 +83,6 @@ As restoring only works when there is a single unit of **etcd**, it is usual to 
 juju deploy etcd new-etcd --series=bionic --config channel=3.2/stable
 juju deploy cs:~containers/easyrsa new-easyrsa --series=bionic
 juju add-relation new-etcd:certificates new-easyrsa:client
-juju add-relation kubeapi-load-balancer:certificates new-easyrsa:client
-juju add-relation kubernetes-master:certificates new-easyrsa:client
-juju add-relation kubernetes-worker:certificates new-easyrsa:client
 ```
 
 The `--series` option is included here to illustrate how to specify which series the new unit should be running on.
@@ -106,8 +103,10 @@ juju run-action new-etcd/0 restore --wait
 Once the restore action has finished, you should see output confirming that the operation is `completed`. The new etcd application will need to be connected to the rest of the deployment:
 
 ```bash
-juju add-relation new-etcd kubernetes-master
 juju add-relation new-etcd flannel
+juju add-relation kubeapi-load-balancer:certificates new-easyrsa:client
+juju add-relation kubernetes-master:certificates new-easyrsa:client
+juju add-relation kubernetes-worker:certificates new-easyrsa:client
 ```
 
 To restore the cluster capabilities of etcd, you can now add more units:


### PR DESCRIPTION
The steps currently described to restore an etcd snapshot deploy
a new easyrsa application, but those steps miss relating it to
kubernetes-worker, kubernetes-master and kubeapi-load-balancer
applications. This patch includes those relations in the
documentation.

Fixes #372