### PR TITLE
Document initContainers workaround for CephFS RWX perm issue

### DIFF
--- a/pages/k8s/storage.md
+++ b/pages/k8s/storage.md
@@ -78,18 +78,20 @@ Due to an upstream issue, containers running as a non-root user with a ReadWrite
 will not be able to write to the mounted directory. This will be fixed with the next release after the
 next OpenStack charms release. In the meantime, you can work around this by adding a simple initContainer
 to your pod to adjust the mounted volume permissions, such as:
-
-```yaml
-  initContainers:
-    - name: fix-cephfs-rwx-volume-perm
-      securityContext:
-        runAsUser: 0
-      image: ubuntu  # or whatever image your pod is using
-      volumeMounts:
-        - name: shared-data  # adjust volume name and mountPath
-          mountPath: /data   # to match your pod spec
-      command: ['chmod', '0777', '/data']
-```
+<div class="language-yaml highlighter-rouge">
+  <div class="highlight">
+    <pre class="highlight">
+    <code>
+initContainers:
+  - name: fix-cephfs-rwx-volume-perm
+    securityContext:
+      runAsUser: 0
+    image: ubuntu  # or whatever image your pod is using
+    volumeMounts:
+      - name: shared-data  # adjust volume name and mountPath
+        mountPath: /data   # to match your pod spec
+    command: ['chmod', '0777', '/data']
+</code></pre></div></div>
 </p></div>
 
 ### Relate to Charmed Kubernetes

--- a/pages/k8s/storage.md
+++ b/pages/k8s/storage.md
@@ -78,7 +78,7 @@ Due to an upstream issue, containers running as a non-root user with a ReadWrite
 will not be able to write to the mounted directory. This will be fixed with the next release after the
 next OpenStack charms release. In the meantime, you can work around this by adding a simple initContainer
 to your pod to adjust the mounted volume permissions, such as:
-<pre><code>
+<code>
 initContainers:
   - name: fix-cephfs-rwx-volume-perm
     securityContext:
@@ -88,7 +88,7 @@ initContainers:
       - name: shared-data  # adjust volume name and mountPath
         mountPath: /data   # to match your pod spec
     command: ['chmod', '0777', '/data']
-</code></pre>
+</code>
 </p></div>
 
 ### Relate to Charmed Kubernetes

--- a/pages/k8s/storage.md
+++ b/pages/k8s/storage.md
@@ -85,7 +85,10 @@ to your pod to adjust the mounted volume permissions, such as:
       securityContext:
         runAsUser: 0
       image: ubuntu  # or whatever image your pod is using
-      command: ['chmod', '0777', '/data']  # adjust the mount point per your pod
+      volumeMounts:
+        - name: shared-data  # adjust volume name and mountPath
+          mountPath: /data   # to match your pod spec
+      command: ['chmod', '0777', '/data']
 ```
 </p></div>
 

--- a/pages/k8s/storage.md
+++ b/pages/k8s/storage.md
@@ -72,6 +72,23 @@ juju add-relation ceph-fs ceph-mon
 **Charmed Kubernetes** will then deploy the CephFS provisioner pod
 and create a `cephfs` storage class in the cluster.
 
+<div class="p-notification--positive"><p markdown="1" class="p-notification__response">
+<span class="p-notification__status">Note:</span>
+Due to an upstream issue, containers running as a non-root user with a ReadWriteMany (RWX) CephFS volume
+will not be able to write to the mounted directory. This will be fixed with the next release after the
+next OpenStack charms release. In the meantime, you can work around this by adding a simple initContainer
+to your pod to adjust the mounted volume permissions, such as:
+
+```yaml
+  initContainers:
+    - name: fix-cephfs-rwx-volume-perm
+      securityContext:
+        runAsUser: 0
+      image: ubuntu  # or whatever image your pod is using
+      command: ['chmod', '0777', '/data']  # adjust the mount point per your pod
+```
+</p></div>
+
 ### Relate to Charmed Kubernetes
 
 Making **Charmed Kubernetes** aware of your **Ceph** cluster requires 2 **Juju** relations.

--- a/pages/k8s/storage.md
+++ b/pages/k8s/storage.md
@@ -78,10 +78,7 @@ Due to an upstream issue, containers running as a non-root user with a ReadWrite
 will not be able to write to the mounted directory. This will be fixed with the next release after the
 next OpenStack charms release. In the meantime, you can work around this by adding a simple initContainer
 to your pod to adjust the mounted volume permissions, such as:
-<div class="language-yaml highlighter-rouge">
-  <div class="highlight">
-    <pre class="highlight">
-    <code>
+<pre><code>
 initContainers:
   - name: fix-cephfs-rwx-volume-perm
     securityContext:
@@ -91,7 +88,7 @@ initContainers:
       - name: shared-data  # adjust volume name and mountPath
         mountPath: /data   # to match your pod spec
     command: ['chmod', '0777', '/data']
-</code></pre></div></div>
+</code></pre>
 </p></div>
 
 ### Relate to Charmed Kubernetes


### PR DESCRIPTION
This documents the workaround for the CephFS RWX volume mount permissions issue that we are stuck with for the time between [LP #1868150](https://bugs.launchpad.net/cdk-addons/+bug/1868150) and [LP #1867940](https://bugs.launchpad.net/cdk-addons/+bug/1867940). This partially mitigates [LP #1866262](https://bugs.launchpad.net/cdk-addons/+bug/1866262) by documenting the interim workaround.