### PR TITLE
Adding containerd version hold to release notes

### DIFF
--- a/pages/k8s/release-notes.md
+++ b/pages/k8s/release-notes.md
@@ -40,12 +40,23 @@ details on the current state of Multus support in Charmed Kubernetes and how to
 get started, please refer to the
 [Multus documentation page](/kubernetes/docs/cni-multus).
 
+- Containerd version hold
+
+The version of [containerd](https://containerd.io/) will now be held.  This means that the version of [containerd](https://containerd.io/) will not be upgraded along with the charm.  To update [containerd](https://containerd.io/) to the latest stable, currently 1.3.3, you can call the `upgrade-containerd` run-action.  For example:
+
+```bash
+juju run-action --wait containerd/0 upgrade-containerd
+```
+
+After completion, the results of the upgrade will be returned.  Run this for each instance of the `containerd` charm.  The upgrades can be staggered to avoid downtime.
+
 ## Component Upgrades
 
 Many of the components in Charmed Kubernetes 1.18 have been upgraded. The following list
 highlights some of the more notable version changes:
 
 - calico xxx
+- containerd 1.3.3 (if `upgrade-containerd` run-action is called)
 - coredns xxx
 - dashboard xxx
 - etcd xxx


### PR DESCRIPTION
Hopefully this will merge neatly into @kwmonroe's branch.  Adding the release notes from https://bugs.launchpad.net/charm-containerd/+bug/1866040