### PR TITLE
Update Multus docs for Juju 2.8.0 stable

### DIFF
--- a/pages/k8s/cni-multus.md
+++ b/pages/k8s/cni-multus.md
@@ -20,26 +20,9 @@ in Juju.
 
 ## Requirements
 
-### Juju 2.8 features
+### Juju 2.8.0
 
-The Multus charm requires functionality from Juju 2.8+, which is currently
-under active development. In order to run Multus, you will need a Juju
-controller running a Juju 2.8 build from edge.
-
-Install the Juju 2.8 client from edge:
-
-```
-sudo snap install juju --channel edge --classic
-```
-
-Or if Juju is already installed, refresh it:
-
-```
-sudo snap refresh juju --channel edge
-```
-
-Once you have the Juju 2.8 edge client, any new controllers you bootstrap will
-include the 2.8 features required by Multus.
+The Multus charm requires Juju 2.8.0 or newer.
 
 ### CNI providers
 

--- a/pages/k8s/release-notes.md
+++ b/pages/k8s/release-notes.md
@@ -37,11 +37,8 @@ possible to attach multiple network interfaces to your pods.
 Along the way, we've also updated existing charms to make it possible for
 multiple CNI providers to be deployed together in the same cluster.
 
-Please note that while we are making Multus support available today, it is
-dependent on functionality in Juju that is not yet considered stable. For more
-details on the current state of Multus support in Charmed Kubernetes and how to
-get started, please refer to the
-[Multus documentation page](/kubernetes/docs/cni-multus).
+For more details on Multus support in Charmed Kubernetes and how to get started,
+please refer to the [Multus documentation page](/kubernetes/docs/cni-multus).
 
 - CIS Benchmark 1.5.0
 


### PR DESCRIPTION
Now that Juju 2.8.0 has been released to stable, we can clean up the Multus instructions a bit.