### PR TITLE
Add an additional call-out in the docs for manage-security-groups

### DIFF
--- a/pages/k8s/openstack-integration.md
+++ b/pages/k8s/openstack-integration.md
@@ -229,6 +229,21 @@ have also been released.
   </p>
 </div>
 
+#### Note: LBaaS and Security Groups
+
+Charmed Kubernetes and the OpenStack integrator assume by default that you will
+be using Octavia for load balancers, and that the Amphora instances providing
+the LBs will reside in the same subnet as the workers and have at least traffic
+on the NodePort range (30000-32767) open from the Amphora instances to the
+worker instances. In general, Juju assumes that traffic between units in a model
+and other resources used by that model is unrestricted or is otherwise managed
+outside of Juju.
+
+If you are instead using Neutron-based LBaaS or have more restrictions on
+traffic between resources within or used by the model, you may need to either
+set the `manage-security-groups` config option on the OpenStack Integrator charm
+to `true`, or manage the security group rules manually.
+
 ### Upgrading the integrator charm
 
 The openstack-integrator is not specifically tied to the version of Charmed Kubernetes installed and may


### PR DESCRIPTION
In [lp:1884995][], there was an apparent misunderstanding of the configuration expected or required for using OpenStack load balancers with Kubernetes in an environment with more restrictive network security rules. This addresses that by calling out what is assumed, and what options are available.

[lp:1884995]: https://bugs.launchpad.net/charm-kubernetes-master/+bug/1884995