### PR TITLE
Create Security section in navigation

### DIFF
--- a/_data/sidebars/k8smain-sidebar.yml
+++ b/_data/sidebars/k8smain-sidebar.yml
@@ -238,6 +238,16 @@ entries:
       output: web, pdf
       type: page
 
+    - title: Certificates and Trust
+      url: /certs-and-trust
+      output: web, pdf
+      type: page
+
+    - title: CIS Compliance
+      url: /cis-compliance
+      output: web, pdf
+      type: page
+
 
   - title: High Availability
     output: web, pdf
@@ -283,7 +293,6 @@ entries:
       output: web, pdf
       type: page
 
-
     - title: Charm Reference
       url: /charm-reference
       output: web, pdf
@@ -291,16 +300,6 @@ entries:
 
     - title: Supported versions
       url: /supported-versions
-      output: web, pdf
-      type: page
-
-    - title: Certificates and Trust
-      url: /certs-and-trust
-      output: web, pdf
-      type: page
-
-    - title: CIS compliance
-      url: /cis-compliance
       output: web, pdf
       type: page
 

--- a/_data/sidebars/k8smain-sidebar.yml
+++ b/_data/sidebars/k8smain-sidebar.yml
@@ -198,21 +198,6 @@ entries:
       output: web, pdf
       type: page
 
-    - title: Authorisation and authentication
-      url: /auth
-      output: web, pdf
-      type: page
-
-    - title: Using Vault as a CA
-      url: /using-vault
-      output: web, pdf
-      type: page
-
-    - title: Encryption at rest
-      url: /encryption-at-rest
-      output: web, pdf
-      type: page
-
     - title: Private Docker registry
       url: /docker-registry
       output: web, pdf
@@ -232,6 +217,27 @@ entries:
       url: /troubleshooting
       output: web, pdf
       type: page
+
+  - title: Security
+    output: web, pdf
+    type: section
+    items:
+
+    - title: Authorisation and authentication
+      url: /auth
+      output: web, pdf
+      type: page
+
+    - title: Using Vault as a CA
+      url: /using-vault
+      output: web, pdf
+      type: page
+
+    - title: Encryption at rest
+      url: /encryption-at-rest
+      output: web, pdf
+      type: page
+
 
   - title: High Availability
     output: web, pdf


### PR DESCRIPTION
Splits out the three security related pages from the somewhat overloaded Operations section of the navigation.