### PR TITLE
Rename "Private Docker Registry" to "Custom Container Registry"

### DIFF
--- a/_data/sidebars/k8smain-sidebar.yml
+++ b/_data/sidebars/k8smain-sidebar.yml
@@ -213,7 +213,7 @@ entries:
       output: web, pdf
       type: page
 
-    - title: Private Docker registry
+    - title: Custom Container Registry
       url: /docker-registry
       output: web, pdf
       type: page

--- a/pages/k8s/docker-registry.md
+++ b/pages/k8s/docker-registry.md
@@ -3,8 +3,8 @@ wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
   nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
-  title: "Private Docker Registry"
-  description: How to use a private Docker registry to serve Docker images to your Kubernetes cluster components.
+  title: "Custom Container Registry"
+  description: How to use a custom container registry to serve images to your Kubernetes cluster components.
 keywords: juju, docker, registry
 tags: [operating]
 sidebar: k8smain-sidebar


### PR DESCRIPTION
The new title is more accurate and less confusing, since the registry doesn't have to be private and we don't use Docker as the runtime by default.