### PR TITLE
Update CephFS notes to exclude Xenial

### DIFF
--- a/pages/k8s/storage.md
+++ b/pages/k8s/storage.md
@@ -74,13 +74,14 @@ and create a `cephfs` storage class in the cluster.
 
 <div class="p-notification--caution"><p markdown="1" class="p-notification__response">
 <span class="p-notification__status">Note:</span>
-CephFS support in Kubernetes requires at least Ubuntu Bionic and OpenStack
-Train, and OpenStack Ussuri or newer is recommended.
+CephFS support in Kubernetes requires at least Ubuntu 18.04LTS and OpenStack
+Train. OpenStack Ussuri or newer is recommended.
 </p></div>
 
-When deploying **Charmed Kubernetes** on Bionic, you will need to explicitly
-set the `install_sources` config option on the `kubernetes-master` charm to
-include `cloud:bionic-ussuri` (or whatever OpenStack release you are using).
+When deploying **Charmed Kubernetes** on Ubuntu 18.04(Bionic), you will need 
+to explicitly set the `install_sources` config option on the `kubernetes-master`
+charm to include `cloud:bionic-ussuri` (or whatever OpenStack release you are
+using).
 
 When using OpenStack Train, ReadWriteMany (RWX) CephFS volumes on containers
 running as a non-root user will be mounted as owned by root instead of the

--- a/pages/k8s/storage.md
+++ b/pages/k8s/storage.md
@@ -72,13 +72,23 @@ juju add-relation ceph-fs ceph-mon
 **Charmed Kubernetes** will then deploy the CephFS provisioner pod
 and create a `cephfs` storage class in the cluster.
 
-<div class="p-notification--positive"><p markdown="1" class="p-notification__response">
+<div class="p-notification--caution"><p markdown="1" class="p-notification__response">
 <span class="p-notification__status">Note:</span>
-Due to an upstream issue, containers running as a non-root user with a ReadWriteMany (RWX) CephFS volume
-will not be able to write to the mounted directory. This will be fixed with the next release after the
-next OpenStack charms release. In the meantime, you can work around this by adding a simple initContainer
-to your pod to adjust the mounted volume permissions, such as:
-<code>
+CephFS support in Kubernetes requires at least Ubuntu Bionic and OpenStack
+Train, and OpenStack Ussuri or newer is recommended.
+</p></div>
+
+When deploying **Charmed Kubernetes** on Bionic, will need to explicitly set
+the `install_sources` config option on the `kubernetes-master` charm to include
+`cloud:bionic-ussuri` (or whatever OpenStack release you are using).
+
+When using OpenStack Train, ReadWriteMany (RWX) CephFS volumes on containers
+running as a non-root user will be mounted as owned by root instead of the
+container's user, potentially leading to permissions issues.  You can work
+around this by adding an initContainer to your pod to adjust the mounted
+volume's ownership or permissions. For example:
+
+```yaml
 initContainers:
   - name: fix-cephfs-rwx-volume-perm
     securityContext:
@@ -88,8 +98,7 @@ initContainers:
       - name: shared-data  # adjust volume name and mountPath
         mountPath: /data   # to match your pod spec
     command: ['chmod', '0777', '/data']
-</code>
-</p></div>
+```
 
 ### Relate to Charmed Kubernetes
 

--- a/pages/k8s/storage.md
+++ b/pages/k8s/storage.md
@@ -78,9 +78,9 @@ CephFS support in Kubernetes requires at least Ubuntu Bionic and OpenStack
 Train, and OpenStack Ussuri or newer is recommended.
 </p></div>
 
-When deploying **Charmed Kubernetes** on Bionic, will need to explicitly set
-the `install_sources` config option on the `kubernetes-master` charm to include
-`cloud:bionic-ussuri` (or whatever OpenStack release you are using).
+When deploying **Charmed Kubernetes** on Bionic, you will need to explicitly
+set the `install_sources` config option on the `kubernetes-master` charm to
+include `cloud:bionic-ussuri` (or whatever OpenStack release you are using).
 
 When using OpenStack Train, ReadWriteMany (RWX) CephFS volumes on containers
 running as a non-root user will be mounted as owned by root instead of the


### PR DESCRIPTION
CephFS support requires OpenStack Train, but according to https://wiki.ubuntu.com/OpenStack/CloudArchive Xenial only goes up to Queens.

Drive-by: Document the need to set the `install_sources` config, and fix the formatting of the `initContainer` example by breaking it out from the note call-out.

Part of [lp:1879542](https://bugs.launchpad.net/charmed-kubernetes-testing/+bug/1879542)