### PR TITLE
need to include --kubeconfig in 1.19+

### DIFF
--- a/pages/k8s/aws-iam-auth.md
+++ b/pages/k8s/aws-iam-auth.md
@@ -275,7 +275,7 @@ between calls.
  * Check verbose output of `kubectl` command by adding `--v=9` such as
 `kubectl get po --v=9`
  * Check the logs of the `aws-iam-authenticator` deployment with
-`juju run --unit kubernetes-master/0 -- /snap/bin/kubectl -n kube-system logs deploy/aws-iam-authenticator`
+`juju run --unit kubernetes-master/0 -- /snap/bin/kubectl --kubeconfig /root/.kube/config -n kube-system logs deploy/aws-iam-authenticator`
  * Check the logs of the API server with `juju run --unit kubernetes-master/0 -- journalctl -u snap.kube-apiserver.daemon.service`
 
 <!-- LINKS -->


### PR DESCRIPTION
With 1.19's CIS benchmark work, we've disabled the insecure addr/port options to the apiserver. This means users will need to explicitly set a `--kubeconfig <file>` when calling `juju run x -- kubectl y`.

A quick grep through the docs only showed 1 required change in the aws-iam page.