### PR TITLE
https_proxy option does not work on kubernetes-worker

### DIFF
--- a/pages/k8s/install-manual.md
+++ b/pages/k8s/install-manual.md
@@ -368,15 +368,17 @@ for example, where we might do the following through **Juju** to set some proxy
 values:
 
 ```bash
-juju config kubernetes-worker https_proxy=https://proxy.example.com
+juju config containerd https_proxy=https://proxy.example.com
 juju config kubernetes-worker snap_proxy:=https://snap-proxy.example.com
 ```
 ... we can instead use the following YAML fragment as an overlay:
 
 ```yaml
-kubernetes-worker:
+containerd:
   options:
     https_proxy: https://proxy.example.com
+kubernetes-worker:
+  options:
     snap_proxy: https://snap-proxy.example.com
 ```
 


### PR DESCRIPTION
Configuration change example contains snippet that sets `https_proxy` option on `kubernetes-worker`, but this option seem to be deprecated and results in error
```
{}
ERROR unknown option "https_proxy"
```
However, the `https_proxy` option can be set on `containerd` app instead.