### PR TITLE
Update MetalLB docs to add MetalLB Operator info

### DIFF
--- a/pages/k8s/metallb.md
+++ b/pages/k8s/metallb.md
@@ -17,7 +17,7 @@ toc: False
 [MetalLB][metallb] is a Kubernetes-aware solution that will monitor for services with
 the type `LoadBalancer` and assign them an IP address from a virtual pool.
 
-It uses BGP([Border Gateway Protocol][bgp]) or ARP([Address Resolution Protocol][arp])
+It uses BGP([Border Gateway Protocol][bgp]) or Layer 2 (with ARP [Address Resolution Protocol][arp])
 to expose services.
 
 MetalLB has support for local traffic, meaning that the machine that receives the

--- a/pages/k8s/metallb.md
+++ b/pages/k8s/metallb.md
@@ -68,7 +68,11 @@ juju deploy cs:~charmed-kubernetes/metallb-operator
 The IP range allocated to MetalLB can be controlled via the configuration of the metallb-controller:
 
 ```bash
-juju config metallb-controller iprange=<IP_RANGE>
+juju config metallb-controller iprange="192.168.1.240-192.168.1.250"
+```
+Multiple IP pools can be specified as well, if using a CIDR notation delimited by a comma:
+```bash
+juju config metallb-controller iprange="192.168.1.240/28, 10.0.0.0/28"
 ```
 
 Currently, to deploy MetalLB in BGP mode, the recommended way is to use the upstream

--- a/pages/k8s/metallb.md
+++ b/pages/k8s/metallb.md
@@ -42,13 +42,30 @@ explanation of the required configuration</a> from the
 
 </p></div>
 
-Currently, the best way to install MetalLB on Charmed Kubernetes is with a helm chart:
+The best way to install MetalLB in layer 2 mode on Charmed Kubernetes is with 
+the MetalLB Operator. The MetalLB Operator is a charm bundle that allows the 
+deployment of both the controller and speaker components.
 
 ```bash
-helm install --name metallb stable/metallb
+juju add-model metallb-system
+juju deploy cs:~charmed-kubernetes/metallb-operator
 ```
-Further configuration can be performed by using a [MetalLB configmap][configmap].
+The ip range allocated to MetalLB is edited via the configuration of the metallb-controller:
 
+```bash
+juju config metallb-controller iprange=<IP_RANGE>
+```
+
+Currently, to deploy MetalLB in BGP mode, the recommended way is to use the upstream
+manifests:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/namespace.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/metallb.yaml
+# On first install only
+kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
+```
+The BGP configuration can then be performed by using a [MetalLB configmap][configmap].
 
 
 <!-- LINKS -->
@@ -57,7 +74,7 @@ Further configuration can be performed by using a [MetalLB configmap][configmap]
 [arp]: https://tools.ietf.org/html/rfc826
 [bgp]: https://tools.ietf.org/html/rfc1105
 [helm]: /kubernetes/docs/helm
-[configmap]: https://metallb.universe.tf/configuration/
+[configmap]: https://metallb.universe.tf/configuration/#bgp-configuration
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">

--- a/pages/k8s/metallb.md
+++ b/pages/k8s/metallb.md
@@ -46,11 +46,26 @@ The best way to install MetalLB in layer 2 mode on Charmed Kubernetes is with
 the MetalLB Operator. The MetalLB Operator is a charm bundle that allows the 
 deployment of both the controller and speaker components.
 
+To deploy the operator, you will first need a Kubernetes model in Juju.
+Add your Kubernetes as a cloud to your Juju controller:
+
+```
+juju add-k8s k8s-cloud --controller $(juju switch | cut -d: -f1)
+```
+
+And create a new Kubernetes model:
+
+```
+juju add-model metallb-system k8s-cloud
+```
+
+Then deploy the MetalLB operator:
+
 ```bash
-juju add-model metallb-system
 juju deploy cs:~charmed-kubernetes/metallb-operator
 ```
-The ip range allocated to MetalLB is edited via the configuration of the metallb-controller:
+
+The IP range allocated to MetalLB can be controlled via the configuration of the metallb-controller:
 
 ```bash
 juju config metallb-controller iprange=<IP_RANGE>

--- a/pages/k8s/metallb.md
+++ b/pages/k8s/metallb.md
@@ -62,7 +62,7 @@ juju add-model metallb-system k8s-cloud
 Then deploy the MetalLB operator:
 
 ```bash
-juju deploy cs:~charmed-kubernetes/metallb-operator
+juju deploy cs:~containers/metallb-operator
 ```
 
 The IP range allocated to MetalLB can be controlled via the configuration of the metallb-controller:
@@ -70,6 +70,7 @@ The IP range allocated to MetalLB can be controlled via the configuration of the
 ```bash
 juju config metallb-controller iprange="192.168.1.240-192.168.1.250"
 ```
+
 Multiple IP pools can be specified as well, if using a CIDR notation delimited by a comma:
 ```bash
 juju config metallb-controller iprange="192.168.1.240/28, 10.0.0.0/28"


### PR DESCRIPTION
This goes with https://github.com/charmed-kubernetes/metallb-operator/pull/1 , the new operator brings a new preferred way to deploy MetalLB in charmed environments.