### PR TITLE
Add info about CoreDNS operator charm

### DIFF
--- a/pages/k8s/cdk-addons.md
+++ b/pages/k8s/cdk-addons.md
@@ -36,8 +36,29 @@ Sourced from: <https://github.com/coredns/deployment.git>
 CoreDNS has been the default DNS provider for Charmed Kubernetes clusters
 since 1.14.
 
-It is possible to use `kube-dns` as the DNS provider, or turn off DNS
-altogether by adjusting the [kubernetes-master configuration][].
+For additional control over CoreDNS, you can also deploy it into the cluster
+using the [CoreDNS Kubernetes operator charm][coredns-charm]. To do so, set
+the `dns-provider` [kubernetes-master configuration][] option to `none` and
+deploy the charm into a Kubernetes model on your cluster. You'll also need
+to cross-model relate it to kubernetes-master:
+
+```bash
+juju config -m cluster-model kubernetes-master dns-provider=none
+juju add-k8s k8s-cloud --controller mycontroller
+juju add-model k8s-model k8s-cloud
+juju deploy cs:~containers/coredns
+juju offer coredns:dns-provider
+juju consume -m cluster-model k8s-model.coredns
+juju relate -m cluster-model coredns kubernetes-master
+```
+
+Once everything settles out, new or restarted pods will use the CoreDNS
+charm as their DNS provider. The CoreDNS charm config allows you to change
+the cluster domain, the IP address or config file to forward unhandled
+queries to, add additional DNS servers, or even override the Corefile entirely.
+
+It is also possible to use `kube-dns` as the DNS provider, or turn off DNS
+altogether using the `dns-provider` [kubernetes-master configuration][].
 
 ## Kubernetes Dashboard
 
@@ -120,3 +141,4 @@ a Prometheus/Grafana/Telegraf stack in the [monitoring docs][].
 [GPU workers page]: /kubernetes/docs/gpu-workers
 [LDAP and Keystone page]: /kubernetes/docs/ldap
 [monitoring docs]: /kubernetes/docs/monitoring
+[coredns-charm]: /kubernetes/docs/charm-coredns


### PR DESCRIPTION
Documents that CoreDNS can be managed via the new operator charm for more customizability.

Part of [lp:1858007](https://bugs.launchpad.net/charmed-kubernetes-bundles/+bug/1858007)