### PR TITLE
Fix cloud-provider-openstack TODO in 1.19 release notes

### DIFF
--- a/pages/k8s/1.19/release-notes.md
+++ b/pages/k8s/1.19/release-notes.md
@@ -89,7 +89,7 @@ For a full list of the changes introduced in Kubernetes 1.19, please see the
 
 - addon-resizer 1.8.9
 - ceph-csi 2.1.2
-- cloud-provider-openstack (TODO https://bugs.launchpad.net/cdk-addons/+bug/1889433)
+- cloud-provider-openstack 1.18.0
 - coredns 1.6.7
 - kube-state-metrics 1.9.7
 - kubernetes-dashboard 2.0.1

--- a/pages/k8s/release-notes.md
+++ b/pages/k8s/release-notes.md
@@ -89,7 +89,7 @@ For a full list of the changes introduced in Kubernetes 1.19, please see the
 
 - addon-resizer 1.8.9
 - ceph-csi 2.1.2
-- cloud-provider-openstack (TODO https://bugs.launchpad.net/cdk-addons/+bug/1889433)
+- cloud-provider-openstack 1.18.0
 - coredns 1.6.7
 - kube-state-metrics 1.9.7
 - kubernetes-dashboard 2.0.1


### PR DESCRIPTION
Stumbled across this TODO in the release notes. Followed it through to [the PR](https://github.com/charmed-kubernetes/cdk-addons/pull/191/files) where we set it to 1.18.0.