### PR TITLE
Remove known issue about Pacemaker from release notes

### DIFF
--- a/pages/k8s/1.19/release-notes.md
+++ b/pages/k8s/1.19/release-notes.md
@@ -115,12 +115,6 @@ cluster now requires an explicit `--kubeconfig <file>` option:
 - The webhook authentication service included in this release runs on port 5000 of each
 kubernetes-master unit. Ensure this port is available prior to upgrading.
 
-- Due to a bug in the pacemaker package on Ubuntu, Charmed Kubernetes does not
-work with HAcluster on Ubuntu 20.04 (Focal). If you intend to use HAcluster,
-we recommend deploying to Ubuntu 18.04 (Bionic) instead. Details
-about this bug can be found at
-[https://bugs.launchpad.net/ubuntu/+source/pacemaker/+bug/1881762](https://bugs.launchpad.net/ubuntu/+source/pacemaker/+bug/1881762).
-
 - Additional known issues scheduled for the first 1.19 bugfix release can be found at [https://launchpad.net/charmed-kubernetes/+milestone/1.19+ck1](https://launchpad.net/charmed-kubernetes/+milestone/1.19+ck1)
 
 ## Deprecations and API changes

--- a/pages/k8s/release-notes.md
+++ b/pages/k8s/release-notes.md
@@ -115,12 +115,6 @@ cluster now requires an explicit `--kubeconfig <file>` option:
 - The webhook authentication service included in this release runs on port 5000 of each
 kubernetes-master unit. Ensure this port is available prior to upgrading.
 
-- Due to a bug in the pacemaker package on Ubuntu, Charmed Kubernetes does not
-work with HAcluster on Ubuntu 20.04 (Focal). If you intend to use HAcluster,
-we recommend deploying to Ubuntu 18.04 (Bionic) instead. Details
-about this bug can be found at
-[https://bugs.launchpad.net/ubuntu/+source/pacemaker/+bug/1881762](https://bugs.launchpad.net/ubuntu/+source/pacemaker/+bug/1881762).
-
 - Additional known issues scheduled for the first 1.19 bugfix release can be found at [https://launchpad.net/charmed-kubernetes/+milestone/1.19+ck1](https://launchpad.net/charmed-kubernetes/+milestone/1.19+ck1)
 
 ## Deprecations and API changes


### PR DESCRIPTION
We should be able to remove this note now that https://bugs.launchpad.net/ubuntu/+source/pacemaker/+bug/1881762 is Fix Released.