### PR TITLE
Updated the kubectl run command example as it has been long deprecated

### DIFF
--- a/pages/k8s/aws-integration.md
+++ b/pages/k8s/aws-integration.md
@@ -177,6 +177,10 @@ be demonstrated with a simple application. Here we will create a simple
 application running in five pods:
 
 ```bash
+# Kubernetes 1.18+
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+
+# Kubernetes 1.17 and below. 
 kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
 ```
 


### PR DESCRIPTION
Hi all, 

The kubectl run command examples which are used on the integrator pages are long-since deprecated. 
I've updated the example to include a working command for kubectl create deployment as opposed to kubectl run. 
This was deprecated as of 1.17 if I recall, but is completely broke as of 1.18+. 

Cheers, 

- Calvin