### PR TITLE
kubectl run example for exposing the load-balancer is wrong

### DIFF
--- a/pages/k8s/azure-integration.md
+++ b/pages/k8s/azure-integration.md
@@ -161,7 +161,19 @@ information see the [storage documentation][storage].
 The following commands start the 'hello-world' pod behind an Azure-backed
 load-balancer.
 
+Here are the commands for Kubernetes 1.18+ and above as the kubectl run command was deprecated: 
+
 ```bash
+# Kubernetes 1.18+
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+kubectl expose deployment hello-world --type=LoadBalancer --name=hello
+watch kubectl get svc -o wide --selector=run=load-balancer-example
+```
+
+Here are the commands for Kubernetes 1.17 and below where the kubectl run command can be used: 
+
+```bash
+# Kubernetes 1.17 and below
 kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
 kubectl expose deployment hello-world --type=LoadBalancer --name=hello
 watch kubectl get svc -o wide --selector=run=load-balancer-example

--- a/pages/k8s/azure-integration.md
+++ b/pages/k8s/azure-integration.md
@@ -167,7 +167,7 @@ Here are the commands for Kubernetes 1.18+ and above as the kubectl run command 
 # Kubernetes 1.18+
 kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0  --port=8080
 kubectl expose deployment hello-world --type=LoadBalancer --name=hello
-watch kubectl get svc -o wide --selector=run=load-balancer-example
+watch kubectl get svc -o wide --selector=app=hello-world
 ```
 
 Here are the commands for Kubernetes 1.17 and below where the kubectl run command can be used: 


### PR DESCRIPTION
Hi all, 

I've updated the azure example for creating a load-balancer with the kubectl create deployment command instead of kubectl run as the command is deprecated and no longer works. 

Cheers,

- Calvin