### PR TITLE
Update all kubectl run commands (now deprecated)

### DIFF
--- a/pages/k8s/1.18/charm-aws-integrator.md
+++ b/pages/k8s/1.18/charm-aws-integrator.md
@@ -213,8 +213,9 @@ The following script starts the hello-world pod behind an AWS Elastic Load Balan
 ```sh
 #!/bin/bash
 
-kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
-kubectl expose deployment hello-world --type=LoadBalancer --name=hello
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0
+kubectl scale deployment hello-world --replicas=5
+kubectl expose deployment hello-world --type=LoadBalancer --name=hello --port=8080
 watch kubectl get svc hello -o wide 
 ```
 

--- a/pages/k8s/1.18/charm-aws-integrator.md
+++ b/pages/k8s/1.18/charm-aws-integrator.md
@@ -213,9 +213,9 @@ The following script starts the hello-world pod behind an AWS Elastic Load Balan
 ```sh
 #!/bin/bash
 
-kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
 kubectl expose deployment hello-world --type=LoadBalancer --name=hello
-watch kubectl get svc -o wide --selector=run=load-balancer-example
+watch kubectl get svc hello -o wide 
 ```
 
 ## Configuration

--- a/pages/k8s/1.18/charm-azure-integrator.md
+++ b/pages/k8s/1.18/charm-azure-integrator.md
@@ -150,9 +150,9 @@ The following script starts the hello-world pod behind an Azure-backed load-bala
 ```sh
 #!/bin/bash
 
-kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
 kubectl expose deployment hello-world --type=LoadBalancer --name=hello
-watch kubectl get svc -o wide --selector=run=load-balancer-example
+watch kubectl get svc hello -o wide 
 ```
 
 ## Configuration

--- a/pages/k8s/1.18/charm-azure-integrator.md
+++ b/pages/k8s/1.18/charm-azure-integrator.md
@@ -147,12 +147,11 @@ EOY
 
 The following script starts the hello-world pod behind an Azure-backed load-balancer.
 
-```sh
-#!/bin/bash
-
-kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
-kubectl expose deployment hello-world --type=LoadBalancer --name=hello
-watch kubectl get svc hello -o wide 
+```bash
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0
+kubectl scale deployment hello-world --replicas=5
+kubectl expose deployment hello-world --type=LoadBalancer --name=hello --port=8080
+watch kubectl get svc hello -o wide
 ```
 
 ## Configuration

--- a/pages/k8s/1.18/charm-gcp-integrator.md
+++ b/pages/k8s/1.18/charm-gcp-integrator.md
@@ -146,7 +146,7 @@ The following script starts the hello-world pod behind a GCE-backed load-balance
 ```sh
 #!/bin/bash
 
-kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
 kubectl expose deployment hello-world --type=LoadBalancer --name=hello
 watch kubectl get svc -o wide --selector=run=load-balancer-example
 ```

--- a/pages/k8s/1.18/charm-gcp-integrator.md
+++ b/pages/k8s/1.18/charm-gcp-integrator.md
@@ -143,12 +143,12 @@ EOY
 
 The following script starts the hello-world pod behind a GCE-backed load-balancer.
 
-```sh
-#!/bin/bash
-
-kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
-kubectl expose deployment hello-world --type=LoadBalancer --name=hello
-watch kubectl get svc hello -o wide 
+```bash
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0
+kubectl scale deployment hello-world --replicas=5
+kubectl expose deployment hello-world --type=LoadBalancer --name=hello --port=8080
+watch kubectl get svc hello -o wide
+```
 
 
 <!-- CONFIG STARTS -->

--- a/pages/k8s/1.18/charm-gcp-integrator.md
+++ b/pages/k8s/1.18/charm-gcp-integrator.md
@@ -148,8 +148,7 @@ The following script starts the hello-world pod behind a GCE-backed load-balance
 
 kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
 kubectl expose deployment hello-world --type=LoadBalancer --name=hello
-watch kubectl get svc -o wide --selector=run=load-balancer-example
-```
+watch kubectl get svc hello -o wide 
 
 
 <!-- CONFIG STARTS -->

--- a/pages/k8s/1.18/charm-openstack-integrator.md
+++ b/pages/k8s/1.18/charm-openstack-integrator.md
@@ -127,7 +127,7 @@ The following script starts the hello-world pod behind a OpenStack-backed load-b
 
 kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
 kubectl expose deployment hello-world --type=LoadBalancer --name=hello
-watch kubectl get svc -o wide --selector=run=load-balancer-example
+watch kubectl get svc hello -o wide
 ```
 
 ## Configuration

--- a/pages/k8s/1.18/charm-openstack-integrator.md
+++ b/pages/k8s/1.18/charm-openstack-integrator.md
@@ -122,11 +122,10 @@ EOY
 
 The following script starts the hello-world pod behind a OpenStack-backed load-balancer.
 
-```sh
-#!/bin/bash
-
-kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
-kubectl expose deployment hello-world --type=LoadBalancer --name=hello
+```bash
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0
+kubectl scale deployment hello-world --replicas=5
+kubectl expose deployment hello-world --type=LoadBalancer --name=hello --port=8080
 watch kubectl get svc hello -o wide
 ```
 

--- a/pages/k8s/1.18/charm-openstack-integrator.md
+++ b/pages/k8s/1.18/charm-openstack-integrator.md
@@ -125,7 +125,7 @@ The following script starts the hello-world pod behind a OpenStack-backed load-b
 ```sh
 #!/bin/bash
 
-kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
 kubectl expose deployment hello-world --type=LoadBalancer --name=hello
 watch kubectl get svc -o wide --selector=run=load-balancer-example
 ```

--- a/pages/k8s/1.19/charm-aws-integrator.md
+++ b/pages/k8s/1.19/charm-aws-integrator.md
@@ -207,12 +207,11 @@ EOY
 
 The following script starts the hello-world pod behind an AWS Elastic Load Balancer.
 
-```sh
-#!/bin/bash
-
-kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
-kubectl expose deployment hello-world --type=LoadBalancer --name=hello
-watch kubectl get svc hello -o wide 
+```bash
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0
+kubectl scale deployment hello-world --replicas=5
+kubectl expose deployment hello-world --type=LoadBalancer --name=hello --port=8080
+watch kubectl get svc hello -o wide
 ```
 
 ## Configuration

--- a/pages/k8s/1.19/charm-aws-integrator.md
+++ b/pages/k8s/1.19/charm-aws-integrator.md
@@ -210,9 +210,9 @@ The following script starts the hello-world pod behind an AWS Elastic Load Balan
 ```sh
 #!/bin/bash
 
-kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
 kubectl expose deployment hello-world --type=LoadBalancer --name=hello
-watch kubectl get svc -o wide --selector=run=load-balancer-example
+watch kubectl get svc hello -o wide 
 ```
 
 ## Configuration

--- a/pages/k8s/1.19/charm-azure-integrator.md
+++ b/pages/k8s/1.19/charm-azure-integrator.md
@@ -149,7 +149,7 @@ The following script starts the hello-world pod behind an Azure-backed load-bala
 
 kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
 kubectl expose deployment hello-world --type=LoadBalancer --name=hello
-watch kubectl get svc -o wide --selector=run=load-balancer-example
+watch kubectl get svc hello -o wide 
 ```
 
 ## Configuration

--- a/pages/k8s/1.19/charm-azure-integrator.md
+++ b/pages/k8s/1.19/charm-azure-integrator.md
@@ -147,7 +147,7 @@ The following script starts the hello-world pod behind an Azure-backed load-bala
 ```sh
 #!/bin/bash
 
-kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
 kubectl expose deployment hello-world --type=LoadBalancer --name=hello
 watch kubectl get svc -o wide --selector=run=load-balancer-example
 ```

--- a/pages/k8s/1.19/charm-azure-integrator.md
+++ b/pages/k8s/1.19/charm-azure-integrator.md
@@ -144,12 +144,11 @@ EOY
 
 The following script starts the hello-world pod behind an Azure-backed load-balancer.
 
-```sh
-#!/bin/bash
-
-kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
-kubectl expose deployment hello-world --type=LoadBalancer --name=hello
-watch kubectl get svc hello -o wide 
+```bash
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0
+kubectl scale deployment hello-world --replicas=5
+kubectl expose deployment hello-world --type=LoadBalancer --name=hello --port=8080
+watch kubectl get svc hello -o wide
 ```
 
 ## Configuration

--- a/pages/k8s/1.19/charm-gcp-integrator.md
+++ b/pages/k8s/1.19/charm-gcp-integrator.md
@@ -143,7 +143,7 @@ The following script starts the hello-world pod behind a GCE-backed load-balance
 ```sh
 #!/bin/bash
 
-kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
 kubectl expose deployment hello-world --type=LoadBalancer --name=hello
 watch kubectl get svc -o wide --selector=run=load-balancer-example
 ```

--- a/pages/k8s/1.19/charm-gcp-integrator.md
+++ b/pages/k8s/1.19/charm-gcp-integrator.md
@@ -140,12 +140,11 @@ EOY
 
 The following script starts the hello-world pod behind a GCE-backed load-balancer.
 
-```sh
-#!/bin/bash
-
-kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
-kubectl expose deployment hello-world --type=LoadBalancer --name=hello
-watch kubectl get svc hello -o wide 
+```bash
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0
+kubectl scale deployment hello-world --replicas=5
+kubectl expose deployment hello-world --type=LoadBalancer --name=hello --port=8080
+watch kubectl get svc hello -o wide
 ```
 
 

--- a/pages/k8s/1.19/charm-gcp-integrator.md
+++ b/pages/k8s/1.19/charm-gcp-integrator.md
@@ -145,7 +145,7 @@ The following script starts the hello-world pod behind a GCE-backed load-balance
 
 kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
 kubectl expose deployment hello-world --type=LoadBalancer --name=hello
-watch kubectl get svc -o wide --selector=run=load-balancer-example
+watch kubectl get svc hello -o wide 
 ```
 
 

--- a/pages/k8s/1.19/charm-openstack-integrator.md
+++ b/pages/k8s/1.19/charm-openstack-integrator.md
@@ -119,12 +119,11 @@ EOY
 
 The following script starts the hello-world pod behind a OpenStack-backed load-balancer.
 
-```sh
-#!/bin/bash
-
-kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
-kubectl expose deployment hello-world --type=LoadBalancer --name=hello
-watch kubectl get svc hello -o wide 
+```bash
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0
+kubectl scale deployment hello-world --replicas=5
+kubectl expose deployment hello-world --type=LoadBalancer --name=hello --port=8080
+watch kubectl get svc hello -o wide
 ```
 
 ## Configuration

--- a/pages/k8s/1.19/charm-openstack-integrator.md
+++ b/pages/k8s/1.19/charm-openstack-integrator.md
@@ -122,7 +122,7 @@ The following script starts the hello-world pod behind a OpenStack-backed load-b
 ```sh
 #!/bin/bash
 
-kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
 kubectl expose deployment hello-world --type=LoadBalancer --name=hello
 watch kubectl get svc -o wide --selector=run=load-balancer-example
 ```

--- a/pages/k8s/1.19/charm-openstack-integrator.md
+++ b/pages/k8s/1.19/charm-openstack-integrator.md
@@ -124,7 +124,7 @@ The following script starts the hello-world pod behind a OpenStack-backed load-b
 
 kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
 kubectl expose deployment hello-world --type=LoadBalancer --name=hello
-watch kubectl get svc -o wide --selector=run=load-balancer-example
+watch kubectl get svc hello -o wide 
 ```
 
 ## Configuration

--- a/pages/k8s/aws-integration.md
+++ b/pages/k8s/aws-integration.md
@@ -176,11 +176,16 @@ Kubernetes  will automatically generate an AWS Elastic Load Balancer.  This can
 be demonstrated with a simple application. Here we will create a simple
 application running in five pods:
 
-```bash
-# Kubernetes 1.18+
-kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+For **Kubernetes 1.18+** and above, use the `kubectl create` command to
+initiate the deployment :
 
-# Kubernetes 1.17 and below. 
+```bash
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
+```
+
+For **Kubernetes 1.17 and earlier** the `kubectl run` command can be used:
+
+```bash
 kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
 ```
 
@@ -293,9 +298,9 @@ If you are an AWS user, you may also be interested in how to
 <!-- FEEDBACK -->
 <div class="p-notification--information">
   <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can 
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/aws-integration.md" class="p-notification__action">edit this page</a> 
-    or 
+    We appreciate your feedback on the documentation. You can
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/aws-integration.md" class="p-notification__action">edit this page</a>
+    or
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
   </p>
 </div>

--- a/pages/k8s/aws-integration.md
+++ b/pages/k8s/aws-integration.md
@@ -174,39 +174,31 @@ with the AWS console to make sure all the associated resources have also been re
 With the aws-integrator charm in place, actions which invoke a loadbalancer in
 Kubernetes  will automatically generate an AWS Elastic Load Balancer.  This can
 be demonstrated with a simple application. Here we will create a simple
-application running in five pods:
-
-For **Kubernetes 1.18+** and above, use the `kubectl create` command to
-initiate the deployment :
+application and scale it to five pods:
 
 ```bash
-kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
-```
-
-For **Kubernetes 1.17 and earlier** the `kubectl run` command can be used:
-
-```bash
-kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0
+kubectl scale deployment hello-world --replicas=5
 ```
 
 You can verify that the application and replicas have been created with:
 
 ```bash
- kubectl get deployments hello-world
- ```
+kubectl get deployments hello-world
+```
 
- Which should return output similar to:
+Which should return output similar to:
 
- ```bash
- NAME              READY   UP-TO-DATE   AVAILABLE   AGE
- hello-world      5/5               5                            5             2m38s
+```bash
+NAME              READY   UP-TO-DATE   AVAILABLE   AGE
+hello-world      5/5               5                            5             2m38s
 ```
 
 To create a LoadBalancer, the application should now be exposed as a service:
 
 ```bash
- kubectl expose deployment hello-world --type=LoadBalancer --name=hello
- ```
+kubectl expose deployment hello-world --type=LoadBalancer --name=hello --port 8080
+```
 
 To check that the service is running correctly:
 

--- a/pages/k8s/azure-integration.md
+++ b/pages/k8s/azure-integration.md
@@ -164,7 +164,7 @@ load-balancer.
 ```bash
 kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
 kubectl expose deployment hello-world --type=LoadBalancer --name=hello
-watch kubectl get svc -o wide --selector=run=load-balancer-example
+watch kubectl get svc hello -o wide
 ```
 
 You can then verify this works by loading the described IP address (on port

--- a/pages/k8s/charm-aws-integrator.md
+++ b/pages/k8s/charm-aws-integrator.md
@@ -212,8 +212,7 @@ The following script starts the hello-world pod behind an AWS Elastic Load Balan
 
 kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
 kubectl expose deployment hello-world --type=LoadBalancer --name=hello
-watch kubectl get svc -o wide --selector=run=load-balancer-example
-```
+watch kubectl get svc hello -o wide 
 
 ## Configuration
 

--- a/pages/k8s/charm-aws-integrator.md
+++ b/pages/k8s/charm-aws-integrator.md
@@ -210,7 +210,7 @@ The following script starts the hello-world pod behind an AWS Elastic Load Balan
 ```sh
 #!/bin/bash
 
-kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
 kubectl expose deployment hello-world --type=LoadBalancer --name=hello
 watch kubectl get svc -o wide --selector=run=load-balancer-example
 ```

--- a/pages/k8s/charm-aws-integrator.md
+++ b/pages/k8s/charm-aws-integrator.md
@@ -207,12 +207,12 @@ EOY
 
 The following script starts the hello-world pod behind an AWS Elastic Load Balancer.
 
-```sh
-#!/bin/bash
-
-kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
-kubectl expose deployment hello-world --type=LoadBalancer --name=hello
-watch kubectl get svc hello -o wide 
+```bash
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0
+kubectl scale deployment hello-world --replicas=5
+kubectl expose deployment hello-world --type=LoadBalancer --name=hello --port=8080
+watch kubectl get svc hello -o wide
+```
 
 ## Configuration
 

--- a/pages/k8s/charm-azure-integrator.md
+++ b/pages/k8s/charm-azure-integrator.md
@@ -144,11 +144,10 @@ EOY
 
 The following script starts the hello-world pod behind an Azure-backed load-balancer.
 
-```sh
-#!/bin/bash
-
-kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
-kubectl expose deployment hello-world --type=LoadBalancer --name=hello
+```bash
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0
+kubectl scale deployment hello-world --replicas=5
+kubectl expose deployment hello-world --type=LoadBalancer --name=hello --port=8080
 watch kubectl get svc hello -o wide
 ```
 

--- a/pages/k8s/charm-azure-integrator.md
+++ b/pages/k8s/charm-azure-integrator.md
@@ -147,7 +147,7 @@ The following script starts the hello-world pod behind an Azure-backed load-bala
 ```sh
 #!/bin/bash
 
-kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
 kubectl expose deployment hello-world --type=LoadBalancer --name=hello
 watch kubectl get svc -o wide --selector=run=load-balancer-example
 ```

--- a/pages/k8s/charm-azure-integrator.md
+++ b/pages/k8s/charm-azure-integrator.md
@@ -149,7 +149,7 @@ The following script starts the hello-world pod behind an Azure-backed load-bala
 
 kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
 kubectl expose deployment hello-world --type=LoadBalancer --name=hello
-watch kubectl get svc -o wide --selector=run=load-balancer-example
+watch kubectl get svc hello -o wide
 ```
 
 ## Configuration

--- a/pages/k8s/charm-gcp-integrator.md
+++ b/pages/k8s/charm-gcp-integrator.md
@@ -143,7 +143,7 @@ The following script starts the hello-world pod behind a GCE-backed load-balance
 ```sh
 #!/bin/bash
 
-kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
 kubectl expose deployment hello-world --type=LoadBalancer --name=hello
 watch kubectl get svc -o wide --selector=run=load-balancer-example
 ```

--- a/pages/k8s/charm-gcp-integrator.md
+++ b/pages/k8s/charm-gcp-integrator.md
@@ -140,12 +140,11 @@ EOY
 
 The following script starts the hello-world pod behind a GCE-backed load-balancer.
 
-```sh
-#!/bin/bash
-
-kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
-kubectl expose deployment hello-world --type=LoadBalancer --name=hello
-watch kubectl get svc hello -o wide 
+```bash
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0
+kubectl scale deployment hello-world --replicas=5
+kubectl expose deployment hello-world --type=LoadBalancer --name=hello --port=8080
+watch kubectl get svc hello -o wide
 ```
 
 

--- a/pages/k8s/charm-gcp-integrator.md
+++ b/pages/k8s/charm-gcp-integrator.md
@@ -145,7 +145,7 @@ The following script starts the hello-world pod behind a GCE-backed load-balance
 
 kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
 kubectl expose deployment hello-world --type=LoadBalancer --name=hello
-watch kubectl get svc -o wide --selector=run=load-balancer-example
+watch kubectl get svc hello -o wide 
 ```
 
 

--- a/pages/k8s/charm-openstack-integrator.md
+++ b/pages/k8s/charm-openstack-integrator.md
@@ -119,11 +119,10 @@ EOY
 
 The following script starts the hello-world pod behind a OpenStack-backed load-balancer.
 
-```sh
-#!/bin/bash
-
-kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
-kubectl expose deployment hello-world --type=LoadBalancer --name=hello
+```bash
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0
+kubectl scale deployment hello-world --replicas=5
+kubectl expose deployment hello-world --type=LoadBalancer --name=hello --port=8080
 watch kubectl get svc hello -o wide
 ```
 

--- a/pages/k8s/charm-openstack-integrator.md
+++ b/pages/k8s/charm-openstack-integrator.md
@@ -124,7 +124,7 @@ The following script starts the hello-world pod behind a OpenStack-backed load-b
 
 kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
 kubectl expose deployment hello-world --type=LoadBalancer --name=hello
-watch kubectl get svc -o wide --selector=run=load-balancer-example
+watch kubectl get svc hello -o wide
 ```
 
 ## Configuration

--- a/pages/k8s/charm-openstack-integrator.md
+++ b/pages/k8s/charm-openstack-integrator.md
@@ -122,7 +122,7 @@ The following script starts the hello-world pod behind a OpenStack-backed load-b
 ```sh
 #!/bin/bash
 
-kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
 kubectl expose deployment hello-world --type=LoadBalancer --name=hello
 watch kubectl get svc -o wide --selector=run=load-balancer-example
 ```

--- a/pages/k8s/gcp-integration.md
+++ b/pages/k8s/gcp-integration.md
@@ -213,40 +213,32 @@ with the GCP console to make sure all the associated resources have also been re
 With the gcp-integrator charm in place, actions which invoke a loadbalancer in
 Kubernetes  will automatically generate a GCP [Target Pool][target-pool] and the
 relevant forwarding rules.  This can be demonstrated with a simple application. Here we
-will create an application running in five pods:
-
-For **Kubernetes 1.18+** and above, use the `kubectl create` command to
-initiate the deployment :
+will create a simple application and scale it to five pods:
 
 ```bash
-kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
-```
-
-For **Kubernetes 1.17 and earlier** the `kubectl run` command can be used:
-
-```bash
-kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0
+kubectl scale deployment hello-world --replicas=5
 ```
 
 You can verify that the application and replicas have been created with:
 
 ```bash
- kubectl get deployments hello-world
- ```
+kubectl get deployments hello-world
+```
 
- Which should return output similar to:
+Which should return output similar to:
 
- ```bash
- NAME              READY   UP-TO-DATE   AVAILABLE   AGE
- hello-world      5/5               5                            5             2m38s
+```bash
+NAME              READY   UP-TO-DATE   AVAILABLE   AGE
+hello-world      5/5               5                            5             2m38s
 ```
 
 To create a target pool load balancer, the application should now be exposed as
 a service:
 
 ```bash
- kubectl expose deployment hello-world --type=LoadBalancer --name=hello
- ```
+kubectl expose deployment hello-world --type=LoadBalancer --name=hello --port 8080
+```
 
 To check that the service is running correctly:
 

--- a/pages/k8s/gcp-integration.md
+++ b/pages/k8s/gcp-integration.md
@@ -215,6 +215,15 @@ Kubernetes  will automatically generate a GCP [Target Pool][target-pool] and the
 relevant forwarding rules.  This can be demonstrated with a simple application. Here we
 will create an application running in five pods:
 
+For **Kubernetes 1.18+** and above, use the `kubectl create` command to
+initiate the deployment :
+
+```bash
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
+```
+
+For **Kubernetes 1.17 and earlier** the `kubectl run` command can be used:
+
 ```bash
 kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
 ```
@@ -323,9 +332,9 @@ juju debug-log --replay --include gcp-integrator/0
 <!-- FEEDBACK -->
 <div class="p-notification--information">
   <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can 
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/gcp-integration.md" class="p-notification__action">edit this page</a> 
-    or 
+    We appreciate your feedback on the documentation. You can
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/gcp-integration.md" class="p-notification__action">edit this page</a>
+    or
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
   </p>
 </div>

--- a/pages/k8s/openstack-integration.md
+++ b/pages/k8s/openstack-integration.md
@@ -177,39 +177,31 @@ have also been released.
 With the openstack-integrator charm in place, actions which invoke a
 loadbalancer in Kubernetes will automatically request a load balancer from
 OpenStack using Octavia. This can be demonstrated with a simple application.
-Here we will create a simple application running in five pods:
-
-For **Kubernetes 1.18+** and above, use the `kubectl create` command to
-initiate the deployment :
+Here we will create a simple application and scale it to five pods:
 
 ```bash
-kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
-```
-
-For **Kubernetes 1.17 and earlier** the `kubectl run` command can be used:
-
-```bash
-kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0
+kubectl scale deployment hello-world --replicas=5
 ```
 
 You can verify that the application and replicas have been created with:
 
 ```bash
- kubectl get deployments hello-world
- ```
+kubectl get deployments hello-world
+```
 
- Which should return output similar to:
+Which should return output similar to:
 
- ```bash
- NAME              READY   UP-TO-DATE   AVAILABLE   AGE
- hello-world      5/5               5                            5             2m38s
+```bash
+NAME              READY   UP-TO-DATE   AVAILABLE   AGE
+hello-world      5/5               5                            5             2m38s
 ```
 
 To create a LoadBalancer, the application should now be exposed as a service:
 
 ```bash
- kubectl expose deployment hello-world --type=LoadBalancer --name=hello
- ```
+kubectl expose deployment hello-world --type=LoadBalancer --name=hello --port 8080
+```
 
 To check that the service is running correctly:
 

--- a/pages/k8s/openstack-integration.md
+++ b/pages/k8s/openstack-integration.md
@@ -179,6 +179,15 @@ loadbalancer in Kubernetes will automatically request a load balancer from
 OpenStack using Octavia. This can be demonstrated with a simple application.
 Here we will create a simple application running in five pods:
 
+For **Kubernetes 1.18+** and above, use the `kubectl create` command to
+initiate the deployment :
+
+```bash
+kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0 --replicas=5 --port=8080
+```
+
+For **Kubernetes 1.17 and earlier** the `kubectl run` command can be used:
+
 ```bash
 kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
 ```
@@ -282,9 +291,9 @@ juju debug-log --replay --include openstack-integrator/0
 <!-- FEEDBACK -->
 <div class="p-notification--information">
   <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can 
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/openstack-integration.md" class="p-notification__action">edit this page</a> 
-    or 
+    We appreciate your feedback on the documentation. You can
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/openstack-integration.md" class="p-notification__action">edit this page</a>
+    or
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
   </p>
 </div>


### PR DESCRIPTION
This only seems of concern in the integrator page examples. This PR fixes the examples in the general pages, the master charm docs and the relevant versioned charm pages.