### PR TITLE
Add section about using openstack-integrator for keystone-credentials

### DIFF
--- a/pages/k8s/ldap.md
+++ b/pages/k8s/ldap.md
@@ -76,10 +76,34 @@ juju unexpose keystone
 juju unexpose openstack-dashboard
 ```
 
+## Using existing Keystone from Openstack model
+
+If you have an existing Keystone application deployed as part of the Openstack in a separate Juju model,
+it is possible to re-use it for authenticating and authorising users in Kubernetes.
+
+To do it, first deploy [openstack-integrator charm][openstack-integrator]
+
+```bash
+juju deploy cs:~containers/openstack-integrator
+```
+Use 'juju trust' to grant openstack-integrator a permission to access Openstack model,
+or configure credentials config parameter manually
+
+```bash
+juju trust openstack-integrator
+```
+
+Finally add a relation between kubernetes-master and openstack-integrator
+
+```bash
+juju add-relation kubernetes-master:keystone-credentials openstack-integrator:keystone-credentials
+```
+
 ## Fetch the Keystone script
 
-When related to Keystone, the Kubernetes master application will generate a utility
-script. This should be copied to the local client with:
+When related to Keystone directly (or to openstack-integrator keystone-credentials interface),
+ the Kubernetes master application will generate a utility script. 
+This should be copied to the local client with:
 
 ```bash
 juju scp kubernetes-master/0:kube-keystone.sh ~/kube-keystone.sh
@@ -292,6 +316,8 @@ configuring Keystone/LDAP.
 [keystone-bundle]: https://raw.githubusercontent.com/juju-solutions/kubernetes-docs/master/assets/keystone.yaml
 [docs-ldap-keystone]: https://jujucharms.com/keystone-ldap
 [trouble]: /kubernetes/docs/troubleshooting/#troubleshooting-keystoneldap-issues
+[openstack-integrator]: /kubernetes/docs/openstack-integration
+
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">

--- a/pages/k8s/ldap.md
+++ b/pages/k8s/ldap.md
@@ -76,24 +76,25 @@ juju unexpose keystone
 juju unexpose openstack-dashboard
 ```
 
-## Using existing Keystone from Openstack model
+## Using existing Keystone from an OpenStack model
 
-If you have an existing Keystone application deployed as part of the Openstack in a separate Juju model,
+If you have an existing Keystone application deployed as part of OpenStack in a separate Juju model,
 it is possible to re-use it for authenticating and authorising users in Kubernetes.
 
-To do it, first deploy [openstack-integrator charm][openstack-integrator]
+To do so, first deploy the [openstack-integrator charm][openstack-integrator]
 
 ```bash
 juju deploy cs:~containers/openstack-integrator
 ```
-Use 'juju trust' to grant openstack-integrator a permission to access Openstack model,
-or configure credentials config parameter manually
+
+Use 'juju trust' to grant openstack-integrator a permission to access the OpenStack model,
+or configure the credentials config parameter manually
 
 ```bash
 juju trust openstack-integrator
 ```
 
-Finally add a relation between kubernetes-master and openstack-integrator
+Finally add a relation between `kubernetes-master` and `openstack-integrator`
 
 ```bash
 juju add-relation kubernetes-master:keystone-credentials openstack-integrator:keystone-credentials
@@ -101,8 +102,8 @@ juju add-relation kubernetes-master:keystone-credentials openstack-integrator:ke
 
 ## Fetch the Keystone script
 
-When related to Keystone directly (or to openstack-integrator keystone-credentials interface),
- the Kubernetes master application will generate a utility script. 
+When related to Keystone directly (or to the `openstack-integrator:keystone-credentials` interface),
+the Kubernetes master application will generate a utility script. 
 This should be copied to the local client with:
 
 ```bash

--- a/pages/k8s/openstack-integration.md
+++ b/pages/k8s/openstack-integration.md
@@ -247,6 +247,11 @@ unrestricted or is otherwise managed outside of Juju.
 If you have more restrictions on traffic between resources within or used by
 the model, you may need to manage the security group rules manually.
 
+### Using Keystone
+
+The `openstack-integrator` also provides an interface for authentication and authorisation using 
+Keystone. This is covered in detail in the [Keystone and LDAP documentation][ldap].
+
 ### Upgrading the integrator charm
 
 The openstack-integrator is not specifically tied to the version of Charmed Kubernetes installed and may
@@ -255,11 +260,6 @@ generally be upgraded at any time with the following command:
 ```bash
 juju upgrade-charm openstack-integrator
 ```
-
-### Using Keystone
-
-The `openstack-integrator` also provides an interface for authentication and authorisation using 
-Keystone. This is covered in detail in the [Keystone and LDAP documentation][ldap].
 
 ### Troubleshooting
 

--- a/pages/k8s/openstack-integration.md
+++ b/pages/k8s/openstack-integration.md
@@ -256,6 +256,11 @@ generally be upgraded at any time with the following command:
 juju upgrade-charm openstack-integrator
 ```
 
+### Using Keystone
+
+The `openstack-integrator` also provides an interface for authentication and authorisation using 
+Keystone. This is covered in detail in the [Keystone and LDAP documentation][ldap].
+
 ### Troubleshooting
 
 If you have any specific problems with the openstack-integrator, you can report bugs on
@@ -278,6 +283,7 @@ juju debug-log --replay --include openstack-integrator/0
 [bugs]: https://bugs.launchpad.net/charmed-kubernetes
 [openstack-integrator-readme]: https://jujucharms.com/u/containers/openstack-integrator/
 [install]: /kubernetes/docs/install-manual
+[ldap]: /kubernetes/docs/ldap
 [charm-config]: https://ubuntu.com/kubernetes/docs/charm-openstack-integrator#configuration
 
 <!-- FEEDBACK -->


### PR DESCRIPTION
The following patches introduced possibility to obtain Keystone credentials from openstack-integrator.
https://review.opendev.org/c/openstack/charm-interface-keystone-credentials/+/747970
https://github.com/juju-solutions/charm-openstack-integrator/pull/38/files

So I'm describing this option in the documentation.