### PR TITLE
Fix command line for secret verification

### DIFF
--- a/pages/k8s/1.19/upgrading.md
+++ b/pages/k8s/1.19/upgrading.md
@@ -252,7 +252,7 @@ juju scp kubernetes-master/0:config ~/.kube/config
 Verify secrets have been created for expected users:
 
 ```bash
-juju run --unit kubernetes-master/0 'kubectl --kubeconfig /root/.kube/config get secrets'
+juju run --unit kubernetes-master/0 'kubectl --kubeconfig /root/.kube/config get secrets -n kube-system --field-selector type=juju.is/token-auth'
 ```
 
 Minimally, secrets for the following users should be listed:


### PR DESCRIPTION
Current command line just gets secrets in the default namespace which does not contain the mentioned secrets
New command line will get them from the kube-system namespace and filter down to just the juju.is/token-auth ones.