### PR TITLE
Add warning for LXD

### DIFF
--- a/pages/k8s/1.20/upgrading.md
+++ b/pages/k8s/1.20/upgrading.md
@@ -27,6 +27,17 @@ This page describes the general upgrade process. It is important to follow the s
 
 <!-- END OF UPGRADE VERSIONS-->
 
+<div class="p-notification--caution">
+  <p markdown="1" class="p-notification__response">
+    <span class="p-notification__status">Caution:</span>
+There is a known issue 
+<a href="https://bugs.launchpad.net/juju/+bug/1904619"> (https://bugs.launchpad.net/juju/+bug/1904619)</a>
+with container profiles not surviving an upgrade. If your container-based applications fail to
+work properly after an upgrade, please see this 
+<a href="/kubernetes/docs/troubleshooting#lxd"> topic on the troubleshooting page</a>
+  </p>
+</div>
+
 
 
 It is recommended that you keep your **Kubernetes** deployment updated to the latest available stable version. You should also update the other applications which make up the **Charmed Kubernetes**. Keeping up to date ensures you have the latest bug-fixes and security patches for smooth operation of your cluster.

--- a/pages/k8s/1.20/upgrading.md
+++ b/pages/k8s/1.20/upgrading.md
@@ -32,8 +32,9 @@ This page describes the general upgrade process. It is important to follow the s
     <span class="p-notification__status">Caution:</span>
 There is a known issue 
 <a href="https://bugs.launchpad.net/juju/+bug/1904619"> (https://bugs.launchpad.net/juju/+bug/1904619)</a>
-with container profiles not surviving an upgrade in clouds running on LXD. If your container-based applications fail to
-work properly after an upgrade, please see this 
+with container profiles not surviving an upgrade when deploying applications to LXD. If your 
+container-based applications fail to work properly after an upgrade, or you use the Juju `localhost` cloud,
+ please see this 
 <a href="/kubernetes/docs/troubleshooting#lxd"> topic on the troubleshooting page</a>
   </p>
 </div>

--- a/pages/k8s/1.20/upgrading.md
+++ b/pages/k8s/1.20/upgrading.md
@@ -32,7 +32,7 @@ This page describes the general upgrade process. It is important to follow the s
     <span class="p-notification__status">Caution:</span>
 There is a known issue 
 <a href="https://bugs.launchpad.net/juju/+bug/1904619"> (https://bugs.launchpad.net/juju/+bug/1904619)</a>
-with container profiles not surviving an upgrade. If your container-based applications fail to
+with container profiles not surviving an upgrade in clouds running on LXD. If your container-based applications fail to
 work properly after an upgrade, please see this 
 <a href="/kubernetes/docs/troubleshooting#lxd"> topic on the troubleshooting page</a>
   </p>

--- a/pages/k8s/troubleshooting.md
+++ b/pages/k8s/troubleshooting.md
@@ -118,8 +118,9 @@ Running the `juju-crashdump` script will generate a tarball of debug information
 <a id="lxd"> </a>
 ### Charms deployed to LXD containers fail after upgrade/reboot
 
-For deployments using Juju's `localhost` cloud, which deploys charms to LXD/LXC containers, there is
-a known issue ([https://bugs.launchpad.net/juju/+bug/1904619](https://bugs.launchpad.net/juju/+bug/1904619))
+For deployments using Juju's `localhost` cloud, which deploys charms to LXD/LXC containers, or other 
+cases where applications are deployed to LXD, there is a known issue
+([https://bugs.launchpad.net/juju/+bug/1904619](https://bugs.launchpad.net/juju/+bug/1904619))
 with the profiles applied by Juju. The LXD profile used by Juju is named after the charm, including
 the revision number. Upgrading the charm causes Juju to create a new profile for LXD which does not
 necessarily contain the same settings which were originally supplied. If services based on LXD

--- a/pages/k8s/troubleshooting.md
+++ b/pages/k8s/troubleshooting.md
@@ -115,6 +115,87 @@ Running the `juju-crashdump` script will generate a tarball of debug information
 
 ## Common Problems
 
+<a id="lxd"> </a>
+### Charms deployed to LXD containers fail after upgrade/reboot
+
+For deployments using Juju's `localhost` cloud, which deploys charms to LXD/LXC containers, there is
+a known issue ([https://bugs.launchpad.net/juju/+bug/1904619](https://bugs.launchpad.net/juju/+bug/1904619))
+with the profiles applied by Juju. The LXD profile used by Juju is named after the charm, including
+the revision number. Upgrading the charm causes Juju to create a new profile for LXD which does not
+necessarily contain the same settings which were originally supplied. If services based on LXD
+containers fail to resume after an upgrade, this is a potential cause of that failure.
+
+To check what the profiles should contain, the YAML output from `juju status` or `juju machines` can be used:
+
+```bash
+juju machines --format=yaml
+```
+... will detail the profiles in the output, e.g.:
+
+```
+model:
+  name: default
+machines:
+  "0":
+...
+    instance-id: juju-4ac678-1
+...
+lxd-profiles:
+      juju-default-kubernetes-worker-718:
+        config:
+          linux.kernel_modules: ip_tables,ip6_tables,netlink_diag,nf_nat,overlay
+          raw.lxc: |
+            lxc.apparmor.profile=unconfined
+            lxc.mount.auto=proc:rw sys:rw
+            lxc.cgroup.devices.allow=a
+            lxc.cap.drop=
+          security.nesting: "true"
+          security.privileged: "true"
+        description: ""
+        devices:
+          aadisable:
+            path: /dev/kmsg
+            source: /dev/kmsg
+            type: unix-char
+
+...
+```
+
+To check this matches with the actually applied profile, you can run `lxc` (this needs to be run on the machine where the containers are running).
+
+```bash
+lxc profile show juju-default-kubernetes-worker-718
+```
+This should give the appropriate corresponding output:
+
+```yaml
+config:
+  linux.kernel_modules: ip_tables,ip6_tables,netlink_diag,nf_nat,overlay
+  raw.lxc: |
+    lxc.apparmor.profile=unconfined
+    lxc.mount.auto=proc:rw sys:rw
+    lxc.cgroup.devices.allow=a
+    lxc.cap.drop=
+  security.nesting: "true"
+  security.privileged: "true"
+description: ""
+devices:
+  aadisable:
+    path: /dev/kmsg
+    source: /dev/kmsg
+    type: unix-char
+name: juju-default-kubernetes-worker-718
+used_by:
+- /1.0/instances/juju-4ac678-1
+```
+
+If this differs from what is expected, the profile can be manually edited. E.g., for the above profile:
+
+```bash
+lxc profile edit juju-default-kubernetes-worker-718
+```
+
+
 ### Load Balancer interfering with Helm
 
 This section assumes you have a working deployment of Kubernetes via Juju using a Load Balancer for the API, and that you are using Helm to deploy charts.

--- a/pages/k8s/upgrade-notes.md
+++ b/pages/k8s/upgrade-notes.md
@@ -19,6 +19,11 @@ The notes are organised according to the upgrade path below, but also be aware t
 upgrade that spans more than one minor version may need to beware of notes in
 any of the intervening steps.
 
+## Upgrades to all versions deployed to Juju's `localhost` LXD based cloud
+
+There is a known issue ([https://bugs.launchpad.net/juju/+bug/1904619](https://bugs.launchpad.net/juju/+bug/1904619))
+with container profiles not surviving an upgrade. If your container-based applications fail to work properly after an upgrade, please see this [topic on the troubleshooting page](/kubernetes/docs/troubleshooting#lxd)
+
 <a  id="1.19"> </a>
 
 ## Upgrading to 1.19

--- a/pages/k8s/upgrade-notes.md
+++ b/pages/k8s/upgrade-notes.md
@@ -22,7 +22,7 @@ any of the intervening steps.
 ## Upgrades to all versions deployed to Juju's `localhost` LXD based cloud
 
 There is a known issue ([https://bugs.launchpad.net/juju/+bug/1904619](https://bugs.launchpad.net/juju/+bug/1904619))
-with container profiles not surviving an upgrade. If your container-based applications fail to work properly after an upgrade, please see this [topic on the troubleshooting page](/kubernetes/docs/troubleshooting#lxd)
+with container profiles not surviving an upgrade in clouds running on LXD. If your container-based applications fail to work properly after an upgrade, please see this [topic on the troubleshooting page](/kubernetes/docs/troubleshooting#lxd)
 
 <a  id="1.19"> </a>
 

--- a/pages/k8s/upgrading.md
+++ b/pages/k8s/upgrading.md
@@ -19,9 +19,9 @@ toc: False
   <p markdown="1" class="p-notification__response">
     <span class="p-notification__status">Note:</span>
 This page describes the general upgrade process. It is important to follow the specific upgrade pages for each release, as these may include additional steps and workarounds for safely upgrading. <br><br>
-<a class='p-button--brand' href='/kubernetes/docs/1.19/upgrading'>Upgrade to 1.20 </a>
-<a class='p-button--brand' href='/kubernetes/docs/1.18/upgrading'>Upgrade to 1.19 </a>
-<a class='p-button--brand' href='/kubernetes/docs/1.17/upgrading'>Upgrade to 1.18 </a>
+<a class='p-button--brand' href='/kubernetes/docs/1.20/upgrading'>Upgrade to 1.20 </a>
+<a class='p-button--brand' href='/kubernetes/docs/1.19/upgrading'>Upgrade to 1.19 </a>
+<a class='p-button--brand' href='/kubernetes/docs/1.18/upgrading'>Upgrade to 1.18 </a>
   </p>
 </div>
 

--- a/pages/k8s/upgrading.md
+++ b/pages/k8s/upgrading.md
@@ -19,9 +19,9 @@ toc: False
   <p markdown="1" class="p-notification__response">
     <span class="p-notification__status">Note:</span>
 This page describes the general upgrade process. It is important to follow the specific upgrade pages for each release, as these may include additional steps and workarounds for safely upgrading. <br><br>
-<a class='p-button--brand' href='/kubernetes/docs/1.19/upgrading'>Upgrade to 1.19 </a>
-<a class='p-button--brand' href='/kubernetes/docs/1.18/upgrading'>Upgrade to 1.18 </a>
-<a class='p-button--brand' href='/kubernetes/docs/1.17/upgrading'>Upgrade to 1.17 </a>
+<a class='p-button--brand' href='/kubernetes/docs/1.19/upgrading'>Upgrade to 1.20 </a>
+<a class='p-button--brand' href='/kubernetes/docs/1.18/upgrading'>Upgrade to 1.19 </a>
+<a class='p-button--brand' href='/kubernetes/docs/1.17/upgrading'>Upgrade to 1.18 </a>
   </p>
 </div>
 


### PR DESCRIPTION
This adds:

 - a section in the troubleshooting page, detailing the problem and a workaround
 - warning at the top of 1.20 upgrade page
 -  warning in the upgrade notes