### PR TITLE
Add 1.19 upgrade note to remove proxy-mode=userspace

### DIFF
--- a/pages/k8s/upgrade-notes.md
+++ b/pages/k8s/upgrade-notes.md
@@ -37,7 +37,7 @@ As of Kubernetes 1.19, kube-proxy's userspace proxier no longer works. Before yo
 upgrade, check the proxy-extra-args configs to make sure that the userspace proxy
 mode is not being used in your cluster:
 
-```
+```bash
 juju config kubernetes-master proxy-extra-args
 juju config kubernetes-worker proxy-extra-args
 ```

--- a/pages/k8s/upgrade-notes.md
+++ b/pages/k8s/upgrade-notes.md
@@ -33,6 +33,18 @@ in the previously used "basic_auth.csv" and "known_tokens.csv" will be migrated 
 secrets and new kubeconfig files will be created during the upgrade. Administrators
 should update any existing kubeconfig files that are used outside of the cluster.
 
+As of Kubernetes 1.19, kube-proxy's userspace proxier no longer works. Before you
+upgrade, check the proxy-extra-args configs to make sure that the userspace proxy
+mode is not being used in your cluster:
+
+```
+juju config kubernetes-master proxy-extra-args
+juju config kubernetes-worker proxy-extra-args
+```
+
+If you see `proxy-mode=userspace` in the charm configs, remove it, then proceed
+with the upgrade.
+
 Please follow the [upgrade instructions for 1.19](/kubernetes/docs/1.19/upgrading).
 
 


### PR DESCRIPTION
Follow-up to https://github.com/charmed-kubernetes/kubernetes-docs/pull/527 and today's office hours. Seems like I forgot upgrade notes for informing users about this change. Hopefully this covers it.