### PR TITLE
Add docs for Azure LB support

### DIFF
--- a/pages/k8s/azure-integration.md
+++ b/pages/k8s/azure-integration.md
@@ -42,8 +42,8 @@ applications:
     num_units: 1
     trust: true
 relations:
-  - ['azure-integrator', 'kubernetes-master']
-  - ['azure-integrator', 'kubernetes-worker']
+  - ['azure-integrator', 'kubernetes-master:azure']
+  - ['azure-integrator', 'kubernetes-worker:azure']
   ```
 
 To use this overlay with the **Charmed Kubernetes** bundle, it is specified
@@ -156,7 +156,7 @@ EOY
 Charmed Kubernetes can make use of additional types of storage - for more
 information see the [storage documentation][storage].
 
-## Azure load-balancers
+## Azure load-balancers for services
 
 The following commands start the 'hello-world' pod behind an Azure-backed
 load-balancer.
@@ -184,6 +184,17 @@ You can then verify this works by loading the described IP address (on port
 
 For more configuration options and details of the permissions which the integrator uses,
 please see the [azure charm page][azure-integrator].
+
+## Azure load-balancers for the control plane
+
+With revision 1015 and later of the `kubernetes-master` charm, Charmed
+Kubernetes can also use Azure native load balancers in front of the control
+plane, replacing the need to deploy the `kubeapi-load-balancer` charm. The
+`kubernetes-master` charm supports two relation endpoints, `loadbalancer-external`
+for a publicly accessible load balancer which can be used by external clients as
+well as the control plane, and `loadbalancer-internal` for a non-public load
+balancer which can only be used by the rest of the control plane but not by
+external clients.
 
 <!-- LINKS -->
 

--- a/pages/k8s/charm-azure-integrator.md
+++ b/pages/k8s/charm-azure-integrator.md
@@ -151,6 +151,24 @@ kubectl expose deployment hello-world --type=LoadBalancer --name=hello --port=80
 watch kubectl get svc hello -o wide
 ```
 
+### Providing load-balancers to other charms
+
+Any charm which supports the `loadbalancer` interface can request an Azure-backed
+load-balancer. For example, you can use an Azure LB to run Vault in HA mode with this:
+
+```yaml
+applications:
+  vault:
+    charm: cs:vault
+    num_units: 3
+  azure-integrator:
+    charm: cs:azure-integrator
+    num_units: 1
+    trust: true
+relations:
+  - ["vault:lb-provider", "azure-integrator"]
+```
+
 ## Configuration
 
 <!-- CONFIG STARTS -->


### PR DESCRIPTION
The docs portion for the Azure Integrator LB support got missed.

Note: I call out the revision for the k8s-master charm because it's still in edge.

Bundle PR for the overlay: https://github.com/charmed-kubernetes/bundle/pull/803