### PR TITLE
Workaround for deploying specific revision.

### DIFF
--- a/pages/k8s/install-manual.md
+++ b/pages/k8s/install-manual.md
@@ -209,7 +209,7 @@ revision number. For example, to deploy the **Charmed Kubernetes** bundle for th
 release, you could run:
 
 ```bash
-juju deploy charmed-kubernetes-596
+juju deploy cs:~containers/charmed-kubernetes-596
 ```
 
 <div class="p-notification--positive">


### PR DESCRIPTION
Deploying specific version is only possible via charmstore, charmhub only supports channels (AFAIK).

$ juju --version
2.9.12-ubuntu-amd64
$ juju deploy charmed-kubernetes-596
"ERROR specifying a revision for charmed-kubernetes is not supported, please use a channel."
$ juju deploy cs:bundle/charmed-kubernetes-596
Located bundle "charmed-kubernetes" in charm-store, revision 596
[...]
Deploy of bundle completed.