### PR TITLE
#bugfix notes - release unknown LP1913228 - Hierarchy standards for kubernetes-master

### DIFF
--- a/pages/k8s/1.22/release-notes.md
+++ b/pages/k8s/1.22/release-notes.md
@@ -117,15 +117,15 @@ in LXD containers.
 - [LP 1936816](https://bugs.launchpad.net/bugs/1936816) and [LP 1913228](https://bugs.launchpad.net/bugs/1913228) Filesystem Hierachy Standards
   
   Applications running inside a kubernetes-master should set pid files and log files in 
-appropriate operational locations like `/run/` and `/var/log/cdk/`. Care was taken to restart 
+appropriate operational locations like `/run/` and `/var/log/kubernetes/`. Care was taken to restart 
 services using these new locations and migrate some existing files out of `/root/cdk/`.
 
   For the service `cdk.master.auth-webhook` the new pid file and log files are named 
-`/run/cdk.master.auth-webhook.pid` and `/var/log/cdk/cdk.master.auth-webhook.log` 
+`/run/cdk.master.auth-webhook.pid` and `/var/log/kubernetes/cdk.master.auth-webhook.log` 
 to match the systemctl service name.
 
   If the [`filebeat`](https://charmhub.io/filebeat) charm is related to kubernetes-master,
-ensure that its logpath include this new path ( e.g. `juju config filebeat logpath='/var/log/cdk/*.log'` )
+ensure that its logpath include this new path ( e.g. `juju config filebeat logpath='/var/log/kubernetes/*.log'` )
 
 ## Deprecations and API changes
 

--- a/pages/k8s/1.22/release-notes.md
+++ b/pages/k8s/1.22/release-notes.md
@@ -72,6 +72,19 @@ This happens when the version of `snapd` on the host does not match the version 
 container. As a workaround, ensure the same version of `snapd` is installed on the host and
 in LXD containers.
 
+- [LP 1936816](https://bugs.launchpad.net/bugs/1936816) and [LP 1913228](https://bugs.launchpad.net/bugs/1913228) Filesystem Hierachy Standards
+  
+  Applications running inside a kubernetes-master should set pid files and log files in 
+appropriate operational locations like `/run/` and `/var/log/cdk/`. Care was taken to restart 
+services using these new locations and migrate some existing files out of `/root/cdk/`.
+
+  For the service `cdk.master.auth-webhook` the new pid file and log files are named 
+`/run/cdk.master.auth-webhook.pid` and `/var/log/cdk/cdk.master.auth-webhook.log` 
+to match the systemctl service name.
+
+  If the [`filebeat`](https://charmhub.io/filebeat) charm is related to kubernetes-master,
+ensure that its logpath include this new path ( e.g. `juju config filebeat logpath='/var/log/cdk/*.log'` )
+
 ## Deprecations and API changes
 
 - Upstream


### PR DESCRIPTION
adding notes about moving auth-webhook logs and pid file for compliance with Filesystem Hierarchy standards