### PR TITLE
Clarify role and usage of subnet and FIP config opts

### DIFF
--- a/pages/k8s/openstack-integration.md
+++ b/pages/k8s/openstack-integration.md
@@ -91,12 +91,12 @@ allow for external access.
     <span class="p-notification__status">Note:</span>
 For security reasons, the security groups automatically managed by Juju will not by default allow
 traffic into the nodes from external networks which can otherwise reach the FIPs. The easiest way to
-allow this is to add a rule to the model SG (named `juju-<model UUID>`) to allow ingress traffic
+allow this is to add a rule to the model security group (named `juju-<model UUID>`) to allow ingress traffic
 from the FIP network, according to your security and network traffic policy and needs.
-Alternatively, you could create a separate SG to manage the rule(s) across multiple models or
+Alternatively, you could create a separate security group to manage the rule(s) across multiple models or
 controllers.<br/>
 <br/>
-Manual SG intervention will also be required if you wish to have the Amphora instances in a
+Configuring or creating a security group will also be necessary if you wish to have the Amphora instances in a
 different subnet from the node instances, since you will need to allow at least traffic on the
 NodePort range (30000-32767) from the Amphorae into the nodes.
   </p>
@@ -106,8 +106,8 @@ NodePort range (30000-32767) from the Amphorae into the nodes.
 
 To use Octavia for `LoadBalancer` type services in the cluster, you will also need to set the
 `subnet-id` config to the appropriate tenant subnet where your nodes reside, and if desired, the
-`floating-network-id` config to whatever network you want FIPs created in.  See the [Charm config
-docs][charm-config] for more details.
+`floating-network-id` config to whatever network you want FIPs created in.  See the 
+[Charm config docs][charm-config] for more details.
 
 As an example of this usage, this will create a simple application, scale it to five pods,
 and expose it with a `LoadBalancer`-type `Service`:

--- a/pages/k8s/openstack-integration.md
+++ b/pages/k8s/openstack-integration.md
@@ -89,11 +89,12 @@ allow for external access.
 <div class="p-notification--caution">
   <p markdown="1" class="p-notification__response">
     <span class="p-notification__status">Note:</span>
-For security reasons, the SGs automatically managed by Juju will not by default allow traffic into
-the nodes from external networks which can otherwise reach the FIPs. The easiest way to allow this
-is to add a rule to the model SG (named `juju-<model UUID>`) to allow ingress traffic from the FIP
-network, according to your security and network traffic policy and needs. Alternatively, you could
-create a separate SG to manage the rule(s) across multiple models or controllers.<br/>
+For security reasons, the security groups automatically managed by Juju will not by default allow
+traffic into the nodes from external networks which can otherwise reach the FIPs. The easiest way to
+allow this is to add a rule to the model SG (named `juju-<model UUID>`) to allow ingress traffic
+from the FIP network, according to your security and network traffic policy and needs.
+Alternatively, you could create a separate SG to manage the rule(s) across multiple models or
+controllers.<br/>
 <br/>
 Manual SG intervention will also be required if you wish to have the Amphora instances in a
 different subnet from the node instances, since you will need to allow at least traffic on the
@@ -156,9 +157,10 @@ Hello Kubernetes!
 
 #### API Server Load Balancer
 
-If desired, the openstack-integrator can also replace kubeapi-load-balancer and create a native OpenStack
-load balancer for the Kubernetes API server, which both reduces the number of machines required and is
-HA. To enable this, use this overlay instead ([download it here][asset-openstack-lb-overlay]):
+If desired, the openstack-integrator can also replace kubeapi-load-balancer and create a native
+OpenStack load balancer for the Kubernetes API server, which simplifies the model and is properly
+HA, which kubeapi-load-balancer on its own is not. To enable this, use this overlay instead
+([download it here][asset-openstack-lb-overlay]):
 
 ```yaml
 applications:

--- a/pages/k8s/openstack-integration.md
+++ b/pages/k8s/openstack-integration.md
@@ -93,8 +93,8 @@ For security reasons, the SGs automatically managed by Juju will not by default 
 the nodes from external networks which can otherwise reach the FIPs. The easiest way to allow this
 is to add a rule to the model SG (named `juju-<model UUID>`) to allow ingress traffic from the FIP
 network, according to your security and network traffic policy and needs. Alternatively, you could
-create a separate SG to manage the rule(s) across multiple models or controllers.
-
+create a separate SG to manage the rule(s) across multiple models or controllers.<br/>
+<br/>
 Manual SG intervention will also be required if you wish to have the Amphora instances in a
 different subnet from the node instances, since you will need to allow at least traffic on the
 NodePort range (30000-32767) from the Amphorae into the nodes.


### PR DESCRIPTION
For the OpenStack integration documentation, the role and distinction between the four config options related to load balancer FIP network and tenant subnet info isn't clearly spelled out and was leading to confusion.