### PR TITLE
adjust release bundle links to github away from charmstore

### DIFF
--- a/pages/k8s/1.17/release-notes.md
+++ b/pages/k8s/1.17/release-notes.md
@@ -15,7 +15,7 @@ toc: False
 
 # 1.17+ck2 Bugfix release
 
-### March 2, 2020 - [charmed-kubernetes-410](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-410/archive/bundle.yaml)
+### March 2, 2020 - [charmed-kubernetes-410](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.17/bundle.yaml)
 
 ## Fixes
 

--- a/pages/k8s/1.18/release-notes.md
+++ b/pages/k8s/1.18/release-notes.md
@@ -15,7 +15,7 @@ toc: False
 
 # 1.18+ck2 Bugfix release
 
-### August 12, 2020 - [charmed-kubernetes-485](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-485/archive/bundle.yaml)
+### August 12, 2020 - [charmed-kubernetes-485](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.18/bundle.yaml)
 
 ## Fixes
 

--- a/pages/k8s/1.19/release-notes.md
+++ b/pages/k8s/1.19/release-notes.md
@@ -15,7 +15,7 @@ toc: False
 
 # 1.19+ck2 Bugfix release
 
-### November 27th, 2020 - [charmed-kubernetes-545](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-545/archive/bundle.yaml)
+### November 27th, 2020 - [charmed-kubernetes-545](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.19/bundle.yaml)
 
 ## Fixes
 A list of bug fixes and other minor feature updates in this release can be found at

--- a/pages/k8s/1.20/release-notes.md
+++ b/pages/k8s/1.20/release-notes.md
@@ -15,7 +15,7 @@ toc: False
 
 # 1.20+ck1 Bugfix release
 
-### February 23rd, 2021 - [charmed-kubernetes-596](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-596/archive/bundle.yaml)
+### February 23rd, 2021 - [charmed-kubernetes-596](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.20/bundle.yaml)
 
 ## Fixes
 

--- a/pages/k8s/1.21/release-notes.md
+++ b/pages/k8s/1.21/release-notes.md
@@ -15,7 +15,7 @@ toc: False
 
 # 1.21+ck3 Bugfix release
 
-### August 02, 2021 - [charmed-kubernetes-733](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-733/archive/bundle.yaml)
+### August 02, 2021 - [charmed-kubernetes-733](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.21/bundle.yaml)
 
 ## Fixes
 

--- a/pages/k8s/1.22/release-notes.md
+++ b/pages/k8s/1.22/release-notes.md
@@ -15,7 +15,7 @@ toc: False
 
 # 1.22+ck2 Bugfix release
 
-### October 27, 2021 - [charmed-kubernetes-814](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-814/archive/bundle.yaml)
+### October 27, 2021 - [charmed-kubernetes-814](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.22/bundle.yaml)
 
 ## Fixes
 

--- a/pages/k8s/1.23/release-notes.md
+++ b/pages/k8s/1.23/release-notes.md
@@ -15,7 +15,7 @@ toc: False
 
 # 1.23
 
-### December 15, 2021 - [charmed-kubernetes-862](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-862/archive/bundle.yaml)
+### December 15, 2021 - [charmed-kubernetes-862](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.23/bundle.yaml)
 
 ## What's new
 

--- a/pages/k8s/install-manual.md
+++ b/pages/k8s/install-manual.md
@@ -230,26 +230,18 @@ versions of the **Charmed Kubernetes** bundle are shown in the table below:
 
 <a  id="table"></a>
 
-| Kubernetes version | Charmed Kubernetes bundle |
-| --- | --- |
-| 1.23.x    | [charmed-kubernetes-862](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-862/archive/bundle.yaml) |
-| 1.22.x    | [charmed-kubernetes-814](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-814/archive/bundle.yaml) |
-| 1.21.x    | [charmed-kubernetes-733](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-733/archive/bundle.yaml) |
-| 1.20.x    | [charmed-kubernetes-596](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-596/archive/bundle.yaml) |
-| 1.19.x    | [charmed-kubernetes-545](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-545/archive/bundle.yaml) |
-| 1.18.x    | [charmed-kubernetes-485](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-485/archive/bundle.yaml) |
-| 1.17.x    | [charmed-kubernetes-410](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-410/archive/bundle.yaml) |
-| 1.16.x    | [charmed-kubernetes-316](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-316/archive/bundle.yaml) |
-| 1.15.x    | [charmed-kubernetes-209](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-209/archive/bundle.yaml) |
-| 1.14.x    | [charmed-kubernetes-124](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-124/archive/bundle.yaml) |
-| 1.13.x    | [canonical-kubernetes-435](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-435/archive/bundle.yaml?channel=stable) |
-| 1.12.x         | [canonical-kubernetes-357](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-357/archive/bundle.yaml?channel=stable) |
-| 1.11.x         | [canonical-kubernetes-254](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-254/archive/bundle.yaml?channel=stable) |
-| 1.10.x         | [canonical-kubernetes-211](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-211/archive/bundle.yaml?channel=stable)  |
-| 1.9.x        | [canonical-kubernetes-179](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-179/archive/bundle.yaml?channel=stable) |
-| 1.8.x | [canonical-kubernetes-132](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-132/archive/bundle.yaml?channel=stable) |
-| 1.7.x | [canonical-kubernetes-101](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-101/archive/bundle.yaml?channel=stable) |
-| 1.6.x | [canonical-kubernetes-38](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-38/archive/bundle.yaml?channel=stable) |
+| Kubernetes version | Charmed Kubernetes bundle                                                                                              |
+| --- |------------------------------------------------------------------------------------------------------------------------------|
+| 1.23.x    | [charmed-kubernetes-862](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.23/bundle.yaml) |
+| 1.22.x    | [charmed-kubernetes-814](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.22/bundle.yaml) |
+| 1.21.x    | [charmed-kubernetes-733](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.21/bundle.yaml) |
+| 1.20.x    | [charmed-kubernetes-596](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.20/bundle.yaml) |
+| 1.19.x    | [charmed-kubernetes-545](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.19/bundle.yaml) |
+| 1.18.x    | [charmed-kubernetes-485](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.18/bundle.yaml) |
+| 1.17.x    | [charmed-kubernetes-410](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.17/bundle.yaml) |
+| 1.16.x    | [charmed-kubernetes-316](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.16/bundle.yaml) |
+| 1.15.x    | [charmed-kubernetes-209](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.15/bundle.yaml) |
+| 1.14.x    | [charmed-kubernetes-124](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.14/bundle.yaml) |
 
 <div class="p-notification--caution">
   <p markdown="1" class="p-notification__response">

--- a/pages/k8s/release-notes-historic.md
+++ b/pages/k8s/release-notes-historic.md
@@ -14,7 +14,7 @@ toc: False
 ---
 # 1.18+ck2 Bugfix release
 
-### August 12, 2020 - [charmed-kubernetes-485](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-485/archive/bundle.yaml)
+### August 12, 2020 - [charmed-kubernetes-485](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.18/bundle.yaml)
 
 ## Fixes
 
@@ -167,7 +167,7 @@ PVCs using those storage classes will hang until the storage class is updated.
 
 # 1.17+ck2 Bugfix release
 
-### March 2, 2020 - [charmed-kubernetes-410](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-410/archive/bundle.yaml)
+### March 2, 2020 - [charmed-kubernetes-410](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.17/bundle.yaml)
 
 ## Fixes
 
@@ -353,7 +353,7 @@ The Kubernetes Dashboard shipped with Charmed Kubernetes 1.16 is version 2.0.0-b
 
 # 1.15+ck1 Bugfix release
 
-### August 15, 2019 - [charmed-kubernetes-209](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-209/archive/bundle.yaml)
+### August 15, 2019 - [charmed-kubernetes-209](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.15/bundle.yaml)
 
 ## Fixes
 
@@ -468,7 +468,7 @@ updated.
 
 # 1.14 Bugfix release
 
-### June 19th, 2019 - [charmed-kubernetes-124](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-124/archive/bundle.yaml)
+### June 19th, 2019 - [charmed-kubernetes-124](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.14/bundle.yaml)
 
 ## Fixes
 

--- a/pages/k8s/release-notes.md
+++ b/pages/k8s/release-notes.md
@@ -15,7 +15,7 @@ toc: False
 
 # 1.23
 
-### December 15, 2021 - [charmed-kubernetes-862](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-862/archive/bundle.yaml)
+### December 15, 2021 - [charmed-kubernetes-862](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.23/bundle.yaml)
 
 ## What's new
 
@@ -74,7 +74,7 @@ relevant sections of the [upstream release notes][upstream-changelog-1.23].
 
 # 1.22+ck2 Bugfix release
 
-### October 27, 2021 - [charmed-kubernetes-814](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-814/archive/bundle.yaml)
+### October 27, 2021 - [charmed-kubernetes-814](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.22/bundle.yaml)
 
 ## Fixes
 
@@ -188,7 +188,7 @@ Please see [this page][rel] for release notes of earlier versions.
 
 # 1.21+ck3 Bugfix release
 
-### August 02, 2021 - [charmed-kubernetes-733](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-733/archive/bundle.yaml)
+### August 02, 2021 - [charmed-kubernetes-733](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.21/bundle.yaml)
 
 ## Fixes
 
@@ -282,7 +282,7 @@ Please see [this page][rel] for release notes of earlier versions.
 
 # 1.20+ck1 Bugfix release
 
-### February 23rd, 2021 - [charmed-kubernetes-596](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-596/archive/bundle.yaml)
+### February 23rd, 2021 - [charmed-kubernetes-596](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.20/bundle.yaml)
 
 ## Fixes
 
@@ -359,7 +359,7 @@ relevant sections of the [upstream release notes](https://github.com/kubernetes/
 
 # 1.19+ck2 Bugfix release
 
-### November 27th, 2020 - [charmed-kubernetes-545](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-545/archive/bundle.yaml)
+### November 27th, 2020 - [charmed-kubernetes-545](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.19/bundle.yaml)
 
 ## Fixes
 A list of bug fixes and other minor feature updates in this release can be found at

--- a/pages/k8s/supported-versions.md
+++ b/pages/k8s/supported-versions.md
@@ -57,24 +57,16 @@ versions of the **Charmed Kubernetes** bundle are shown in the table below:
 
 | Kubernetes version | Charmed Kubernetes bundle |
 | --- | --- |
-| 1.23.x    | [charmed-kubernetes-862](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-862/archive/bundle.yaml) |
-| 1.22.x    | [charmed-kubernetes-814](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-814/archive/bundle.yaml) |
-| 1.21.x    | [charmed-kubernetes-733](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-733/archive/bundle.yaml) |
-| 1.20.x    | [charmed-kubernetes-596](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-596/archive/bundle.yaml) |
-| 1.19.x    | [charmed-kubernetes-545](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-545/archive/bundle.yaml) |
-| 1.18.x    | [charmed-kubernetes-485](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-485/archive/bundle.yaml) |
-| 1.17.x    | [charmed-kubernetes-410](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-410/archive/bundle.yaml) |
-| 1.16.x    | [charmed-kubernetes-316](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-316/archive/bundle.yaml) |
-| 1.15.x    | [charmed-kubernetes-209](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-209/archive/bundle.yaml) |
-| 1.14.x    | [charmed-kubernetes-124](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-124/archive/bundle.yaml) |
-| 1.13.x    | [canonical-kubernetes-435](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-435/archive/bundle.yaml?channel=stable) |
-| 1.12.x         | [canonical-kubernetes-357](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-357/archive/bundle.yaml?channel=stable) |
-| 1.11.x         | [canonical-kubernetes-254](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-254/archive/bundle.yaml?channel=stable) |
-| 1.10.x         | [canonical-kubernetes-211](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-211/archive/bundle.yaml?channel=stable)  |
-| 1.9.x        | [canonical-kubernetes-179](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-179/archive/bundle.yaml?channel=stable) |
-| 1.8.x | [canonical-kubernetes-132](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-132/archive/bundle.yaml?channel=stable) |
-| 1.7.x | [canonical-kubernetes-101](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-101/archive/bundle.yaml?channel=stable) |
-| 1.6.x | [canonical-kubernetes-38](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-38/archive/bundle.yaml?channel=stable) |
+| 1.23.x    | [charmed-kubernetes-862](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.23/bundle.yaml) |
+| 1.22.x    | [charmed-kubernetes-814](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.22/bundle.yaml) |
+| 1.21.x    | [charmed-kubernetes-733](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.21/bundle.yaml) |
+| 1.20.x    | [charmed-kubernetes-596](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.20/bundle.yaml) |
+| 1.19.x    | [charmed-kubernetes-545](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.19/bundle.yaml) |
+| 1.18.x    | [charmed-kubernetes-485](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.18/bundle.yaml) |
+| 1.17.x    | [charmed-kubernetes-410](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.17/bundle.yaml) |
+| 1.16.x    | [charmed-kubernetes-316](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.16/bundle.yaml) |
+| 1.15.x    | [charmed-kubernetes-209](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.15/bundle.yaml) |
+| 1.14.x    | [charmed-kubernetes-124](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/releases/1.14/bundle.yaml) |
 
 <div class="p-notification--caution">
   <p markdown="1" class="p-notification__response">


### PR DESCRIPTION
Addresses #643 immediately, while other links still exist to charmstore bundles.  

