### PR TITLE
Remove ceph-admin relation from storage docs

### DIFF
--- a/pages/k8s/storage.md
+++ b/pages/k8s/storage.md
@@ -103,10 +103,9 @@ initContainers:
 
 ### Relate to Charmed Kubernetes
 
-Making **Charmed Kubernetes** aware of your **Ceph** cluster requires 2 **Juju** relations.
+Making **Charmed Kubernetes** aware of your **Ceph** cluster requires a **Juju** relation.
 
 ```bash
-juju add-relation ceph-mon:admin kubernetes-master
 juju add-relation ceph-mon:client kubernetes-master
 ```
 


### PR DESCRIPTION
In CK 1.24 we will no longer be supporting the ceph-admin relation (kubernetes-control-plane:ceph-storage <-> ceph-mon:admin). The kubernetes-control-plane charm will get everything it needs from the ceph-client relation instead.

Let me know if there's a different branch I should target this change to.