### PR TITLE
Add changes for updated CoreDNS charm

### DIFF
--- a/pages/k8s/cdk-addons.md
+++ b/pages/k8s/cdk-addons.md
@@ -46,7 +46,7 @@ to cross-model relate it to kubernetes-control-plane:
 juju config -m cluster-model kubernetes-control-plane dns-provider=none
 juju add-k8s k8s-cloud --controller mycontroller
 juju add-model k8s-model k8s-cloud
-juju deploy cs:~containers/coredns
+juju deploy coredns --channel=latest/stable --trust
 juju offer coredns:dns-provider
 juju consume -m cluster-model k8s-model.coredns
 juju relate -m cluster-model coredns kubernetes-control-plane
@@ -56,9 +56,6 @@ Once everything settles out, new or restarted pods will use the CoreDNS
 charm as their DNS provider. The CoreDNS charm config allows you to change
 the cluster domain, the IP address or config file to forward unhandled
 queries to, add additional DNS servers, or even override the Corefile entirely.
-
-It is also possible to use `kube-dns` as the DNS provider, or turn off DNS
-altogether using the `dns-provider` [kubernetes-control-plane configuration][].
 
 ## Kubernetes Dashboard
 
@@ -224,7 +221,7 @@ This charm offers the following options
 [GPU workers page]: /kubernetes/docs/gpu-workers
 [LDAP and Keystone page]: /kubernetes/docs/ldap
 [monitoring docs]: /kubernetes/docs/monitoring
-[coredns-charm]: https://jaas.ai/u/containers/coredns
+[coredns-charm]: https://charmhub.io/coredns
 [kubernetes-dashboard-bundle]: https://jaas.ai/u/containers/kubernetes-dashboard-bundle
 [kube-state-metrics example]: https://github.com/kubernetes/kube-state-metrics/tree/master/examples/standard
 [metrics-server releases]: https://github.com/kubernetes-sigs/metrics-server/releases


### PR DESCRIPTION
DO NOT MERGE UNTIL COREDNS CHARM IS IN LATEST/STABLE TRACK.

This PR updates the instructions for deploying coreDNS to use the latest/stable track and adds a --trust flag since the CoreDNS charm now requires trust in order to apply some RBAC resources. It also fixes the link for the charm to point to charmhub. 