### PR TITLE
focus on calico as the 1.24 default cni

### DIFF
--- a/pages/k8s/cni-calico.md
+++ b/pages/k8s/cni-calico.md
@@ -51,15 +51,9 @@ documentation for instructions.
 
 ## Deploying Charmed Kubernetes with Calico
 
-To deploy Charmed Kubernetes with Calico, deploy the kubernetes-calico bundle:
-
-```bash
-juju deploy kubernetes-calico
-```
-
-The Calico bundle is identical to the standard `charmed-kubernetes` bundle with the
-exception of replacing Flannel with Calico. You can apply any customisation overlays
-that would apply to `charmed-kubernetes` to this bundle also.
+Calico became the default choice for networking with **Charmed Kubernetes** 1.24.
+If you [deploy the bundle][quickstart] without changing the default settings,
+calico will be the CNI.
 
 ## Calico configuration options
 

--- a/pages/k8s/cni-canal.md
+++ b/pages/k8s/cni-canal.md
@@ -23,15 +23,15 @@ special configuration.
 
 ## Deploying Charmed Kubernetes with Canal
 
-To deploy a cluster with Canal, deploy the kubernetes-canal bundle:
+To deploy a cluster with Canal, deploy the `charmed-kubernetes` bundle with the
+[canal overlay][canal-overlay]:
 
 ```bash
-juju deploy cs:bundle/canonical-kubernetes-canal
+juju deploy charmed-kubernetes --overlay canal-overlay.yaml
 ```
 
-The canal bundle is identical to the standard `charmed-kubernetes` bundle with the
-exception of replacing flannel with canal. You can apply any customisation overlays
-that would apply to `charmed-kubernetes` to this bundle also.
+You can apply any additional customisation overlays that would apply to
+`charmed-kubernetes` to this deployment as well.
 
 ## Canal configuration options
 
@@ -76,6 +76,7 @@ For additional troubleshooting pointers, please see the
 <!-- LINKS -->
 
 [canal]: https://docs.projectcalico.org/v3.7/getting-started/kubernetes/installation/flannel
+[canal-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/overlays/canal-overlay.yaml
 [troubleshooting]: /kubernetes/docs/troubleshooting
 
 <!-- FEEDBACK -->

--- a/pages/k8s/cni-flannel.md
+++ b/pages/k8s/cni-flannel.md
@@ -17,14 +17,20 @@ toc: False
 [Flannel][] is a simple, lightweight layer 3 fabric for Kubernetes. Flannel manages an
 IPv4 network between multiple nodes in a cluster. It does not control how containers
 are networked to the host, only how the traffic is transported between hosts. For
-more complicated scenarios, see also [Calico][] and [Canal][]
+more complicated scenarios, see also [Calico][] and [Canal][].
 
 
-## Deploying **Charmed Kubernetes** with flannel
+## Deploying Charmed Kubernetes with Flannel
 
-Flannel is the default choice for networking with **Charmed Kubernetes**. If you
-[deploy the bundle][quickstart] without changing the default settings,
-flannel will be used for CNI.
+To deploy a cluster with Flannel, deploy the `charmed-kubernetes` bundle with the
+[flannel overlay][flannel-overlay]:
+
+```bash
+juju deploy charmed-kubernetes --overlay flannel-overlay.yaml
+```
+
+You can apply any additional customisation overlays that would apply to
+`charmed-kubernetes` to this deployment as well.
 
 ## Flannel options
 
@@ -68,6 +74,7 @@ For additional troubleshooting pointers, please see the [dedicated troubleshooti
 <!-- LINKS -->
 
 [Flannel]: https://github.com/coreos/flannel
+[flannel-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/overlays/flannel-overlay.yaml
 [troubleshooting]: /kubernetes/docs/troubleshooting
 [quickstart]:  /kubernetes/docs/quickstart
 [install-manual]:  /kubernetes/docs/install-manual

--- a/pages/k8s/cni-overview.md
+++ b/pages/k8s/cni-overview.md
@@ -29,12 +29,12 @@ Kubernetes**, which are listed below:
 
 The currently supported base CNI solutions for **Charmed Kubernetes** are:
 
- -   [Flannel][flannel]
  -   [Calico][calico]
  -   [Canal][canal]
+ -   [Flannel][flannel]
  -   [Tigera Secure EE][tigera]
 
-By default, **Charmed Kubernetes** will deploy the cluster using flannel. To chose a different CNI provider, see the individual links above.
+By default, **Charmed Kubernetes** will deploy the cluster using calico. To chose a different CNI provider, see the individual links above.
 
 The following CNI addons are also available:
  -   [Multus][multus]
@@ -49,9 +49,9 @@ Kubernetes, such a migration should be manageable with no downtime.
 
 <!-- LINKS -->
 
-[flannel]: /kubernetes/docs/cni-flannel
 [calico]: /kubernetes/docs/cni-calico
 [canal]: /kubernetes/docs/cni-canal
+[flannel]: /kubernetes/docs/cni-flannel
 [tigera]: /kubernetes/docs/tigera-secure-ee
 [multus]: /kubernetes/docs/cni-multus
 [sr-iov]: /kubernetes/docs/cni-sriov

--- a/pages/k8s/install-manual.md
+++ b/pages/k8s/install-manual.md
@@ -40,11 +40,8 @@ containers to create a cluster), please see the separate
 
 ## Quick custom installs
 
-
-The details of how to edit and customise the **Charmed Kubernetes** bundle are
-outlined [below](#). However, using overlays (also explained in more
-detail below) you can make some common quick customisations for networking and
-cloud integration.
+Bundle overlays facilitate common, quick customisations for components such as
+networking and cloud integration.
 
 Overlay files can be applied when deploying Charmed Kubernetes by specifying them along with the deploy command:
 
@@ -65,15 +62,15 @@ each category!
 <div class="CNI">
  <div class="row">
  <div class="col-2 ">
-   <span>Calico</span>
+   <span>Flannel</span>
  </div>
   <div class="col-4 ">
-   <span>Calico provides out-of-the-box support for the
-   NetworkPolicy feature of Kubernetes, along with different modes of
-   network encapsulation. <a href="/kubernetes/docs/cni-calico"> Read more...</a></span>
+   <span>Flannel is a simple, lightweight layer 3 fabric for Kubernetes.
+   It manages an IPv4 network between multiple nodes in a cluster.
+   <a href="/kubernetes/docs/cni-flannel"> Read more...</a></span>
   </div>
   <div class="col-3 ">
-    <span><a href="https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/overlays/calico-overlay.yaml" class="p-button--positive">Download calico-overlay.yaml</a></span>
+    <span><a href="https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/overlays/flannel-overlay.yaml" class="p-button--positive">Download flannel-overlay.yaml</a></span>
   </div>
 </div>
 <br>
@@ -107,7 +104,7 @@ each category!
 <div class="p-notification--positive is-inline">
   <div markdown="1" class="p-notification__content">
     <span class="p-notification__title">Note:</span>
-    <p class="p-notification__message">By default, Charmed Kubernetes uses <em>Flannel</em> for networking. You can read more about CNI support <a href="/kubernetes/docs/cni-overview"> here </a>.</p>
+    <p class="p-notification__message">By default, Charmed Kubernetes uses <em>Calico</em> for networking. You can read more about CNI support <a href="/kubernetes/docs/cni-overview"> here </a>.</p>
   </div>
 </div>
 


### PR DESCRIPTION
- highlight calico as the default CNI in CK 1.24
- callout CNI overlays instead of bespoke bundles