### PR TITLE
Remove references to calico-overlay.yaml

### DIFF
--- a/pages/k8s/install-manual.md
+++ b/pages/k8s/install-manual.md
@@ -181,10 +181,10 @@ each category!
 
 You can use multiple overlays (of different types) if required.  Note that all
 the 'integrator' charms require the use of the `--trust` option. For example,
-to deploy with Calico networking and AWS integration:
+to deploy with Canal networking and AWS integration:
 
 ```bash
-juju deploy charmed-kubernetes --overlay aws-overlay.yaml --trust --overlay calico-overlay.yaml
+juju deploy charmed-kubernetes --overlay aws-overlay.yaml --trust --overlay canal-overlay.yaml
 ```
 
 For more detail on overlays and how they work, see the section [below](#overlay).

--- a/pages/k8s/ipv6.md
+++ b/pages/k8s/ipv6.md
@@ -175,7 +175,6 @@ No additional issues with IPv6 on MAAS are known at this time.
 
 [dual-stack]: https://kubernetes.io/docs/concepts/services-networking/dual-stack/
 [ip-families]: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services
-[asset-calico-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/overlays/calico-overlay.yaml
 [asset-ipv4-ipv6-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/overlays/ipv4-ipv6-overlay.yaml
 [asset-nginx-dual-stack]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/specs/nginx-dual-stack.yaml
 


### PR DESCRIPTION
Calico is now the default CNI, so calico-overlay.yaml doesn't really make sense anymore. Let's remove references to it.

Related: https://github.com/charmed-kubernetes/bundle/pull/849