### PR TITLE
Update release docs to indicate new charms

### DIFF
--- a/pages/k8s/1.25/release-notes.md
+++ b/pages/k8s/1.25/release-notes.md
@@ -27,7 +27,7 @@ Notable additions in this release include:
   Kubernetes 1.25, the charm must not allow these to be set `False`.  This means that in-tree storage
   provided by AWS is only supported in 1.25 and beyond with an [out-of-tree deployment](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/).
 
-  [aws-k8s-storage](https://charmhub.io/aws-k8s-storage) provides the out-of-tree deployment in charm.
+  [aws-k8s-storage](https://charmhub.io/aws-k8s-storage) provides the out-of-tree deployment as a charm.
 
 - GCE in Kubernetes-Control-Plane / Kubernetes-Worker [LP#1988186](https://bugs.launchpad.net/bugs/1988186)
 

--- a/pages/k8s/1.25/release-notes.md
+++ b/pages/k8s/1.25/release-notes.md
@@ -13,6 +13,31 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+# 1.25 Point Release
+
+### October ??, 2022
+
+## Additions
+
+Notable additions in this release include:
+
+- AwsEbs in Kubernetes-Control-Plane / Kubernetes-Worker [LP#1988186](https://bugs.launchpad.net/bugs/1988186)
+
+  With the pinning of [CSIMigrationAWS=True](https://github.com/kubernetes/kubernetes/pull/111479) in 
+  Kubernetes 1.25, the charm must not allow these to be set `False`.  This means that in-tree storage
+  provided by AWS is only supported in 1.25 and beyond with an [out-of-tree deployment](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/).
+
+  [aws-k8s-storage](https://charmhub.io/aws-k8s-storage) provides the out-of-tree deployment in charm.
+
+- GCE in Kubernetes-Control-Plane / Kubernetes-Worker [LP#1988186](https://bugs.launchpad.net/bugs/1988186)
+
+  With the pinning of [CSIMigrationGCE=True](https://github.com/kubernetes/kubernetes/pull/111301) in 
+  Kubernetes 1.25, the charm must not allow these to be set `False`.  This means that in-tree storage
+  provided by GCE is only supported in 1.25 and beyond with an [out-of-tree deployment](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver).
+
+  [gcp-k8s-storage](https://charmhub.io/gcp-k8s-storage) provides the out-of-tree deployment as a charm.
+
+
 # 1.25+ck2 Bugfix release 
 
 ### September 30, 2022 - `charmed-kubernetes --channel 1.25/stable`

--- a/pages/k8s/release-notes.md
+++ b/pages/k8s/release-notes.md
@@ -28,7 +28,7 @@ Notable additions in this release include:
   Kubernetes 1.25, the charm must not allow these to be set `False`.  This means that in-tree storage
   provided by AWS is only supported in 1.25 and beyond with an [out-of-tree deployment](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/).
 
-  [aws-k8s-storage](https://charmhub.io/aws-k8s-storage) provides the out-of-tree deployment in charm.
+  [aws-k8s-storage](https://charmhub.io/aws-k8s-storage) provides the out-of-tree deployment as a charm.
 
 - GCE in Kubernetes-Control-Plane / Kubernetes-Worker [LP#1988186](https://bugs.launchpad.net/bugs/1988186)
 

--- a/pages/k8s/release-notes.md
+++ b/pages/k8s/release-notes.md
@@ -14,6 +14,30 @@ toc: False
 ---
 
 <!-- AUTOGENERATE RELEASE NOTES HERE -->
+# 1.25 Point Release
+
+### October ??, 2022
+
+## Additions
+
+Notable additions in this release include:
+
+- AwsEbs in Kubernetes-Control-Plane / Kubernetes-Worker [LP#1988186](https://bugs.launchpad.net/bugs/1988186)
+
+  With the pinning of [CSIMigrationAWS=True](https://github.com/kubernetes/kubernetes/pull/111479) in 
+  Kubernetes 1.25, the charm must not allow these to be set `False`.  This means that in-tree storage
+  provided by AWS is only supported in 1.25 and beyond with an [out-of-tree deployment](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/).
+
+  [aws-k8s-storage](https://charmhub.io/aws-k8s-storage) provides the out-of-tree deployment in charm.
+
+- GCE in Kubernetes-Control-Plane / Kubernetes-Worker [LP#1988186](https://bugs.launchpad.net/bugs/1988186)
+
+  With the pinning of [CSIMigrationGCE=True](https://github.com/kubernetes/kubernetes/pull/111301) in 
+  Kubernetes 1.25, the charm must not allow these to be set `False`.  This means that in-tree storage
+  provided by GCE is only supported in 1.25 and beyond with an [out-of-tree deployment](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver).
+
+  [gcp-k8s-storage](https://charmhub.io/gcp-k8s-storage) provides the out-of-tree deployment as a charm.
+
 
 # 1.25+ck2 Bugfix release 
 


### PR DESCRIPTION
* release date currently unset
*  should the [known-issues sections](https://github.com/charmed-kubernetes/kubernetes-docs/blob/6fe5300219a9030b45015cdf3c15b45bc335a2e6/pages/k8s/release-notes.md?plain=1#L184-L195) be updated to remove the warnings