### PR TITLE
Add necessary model configuration command for certain clusters

### DIFF
--- a/pages/k8s/vsphere-integration.md
+++ b/pages/k8s/vsphere-integration.md
@@ -31,6 +31,14 @@ vSphere servers. Using the credentials provided to **Juju**, it acts as a proxy 
 Charmed Kubernetes and the underlying cloud, granting permissions to
 dynamically create, for example, storage.
 
+### Model configuration
+
+If the cluster has multiple datastores or a non-default network name, you'll need to configure the model defaults before deployment. For example:
+
+```bash
+juju model-config datastore=mydatastore primary-network=mynetwork
+```
+
 ### Installing
 
 If you install **Charmed Kubernetes** [using the Juju bundle][install],


### PR DESCRIPTION
When I was setting up a test cluster on our Boston vSphere, I needed to run `juju model-config` to set the `datastore` and `primary-network` config variables.

In the case of the Boston cluster, the exact command I used was:

juju model-config datastore=vsanDatastore primary-network=VLAN_2767