### PR TITLE
Update vSphere Integration docs

### DIFF
--- a/generator/tox.ini
+++ b/generator/tox.ini
@@ -3,7 +3,7 @@ envlist = lint, unit
 skipsdist=true
 
 [testenv]
-passenv = GITHUB_TOKEN RELEASE
+passenv = GITHUB_TOKEN, RELEASE
 
 [testenv:lint]
 commands =

--- a/pages/k8s/vsphere-integration.md
+++ b/pages/k8s/vsphere-integration.md
@@ -4,7 +4,7 @@ markdown_includes:
   nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Charmed Kubernetes on vSphere"
-  description: Running Charmed Kubernetes on vSphere using the integrator.
+  description: Running Charmed Kubernetes on vSphere using the out-of-tree provider.
 keywords: vsphere, integrator
 tags: [install]
 sidebar: k8smain-sidebar
@@ -14,22 +14,28 @@ toc: False
 ---
 
 **Charmed Kubernetes** will install and run on vSphere virtual servers.
-With the  addition of the `vsphere-integrator`, your cluster will also be able
+With the  addition of the `vsphere-cloud-provider` and the `vsphere-integrator`, your cluster will also be able
 to directly use native vSphere features such as storage.
 
 <div class="p-notification--information is-inline">
   <div class="p-notification__content">
     <span class="p-notification__title">Note:</span>
-    <p class="p-notification__message">These instructions for deploying Charmed Kubernetes with the vSphere integrator assume that Juju has been configured appropriately for your vSphere server. For reference, the configuration options may be found in the <a href="https://juju.is/docs/olm/vmware-vsphere" >Juju documentation</a>.</p>
+    <p class="p-notification__message">These instructions for deploying Charmed Kubernetes with the vSphere Cloud Provider assume that Juju has been configured appropriately for your vSphere server. For reference, the configuration options may be found in the <a href="https://juju.is/docs/olm/vmware-vsphere" >Juju documentation</a>.</p>
   </div>
 </div>
+
+## vSphere Cloud Provider
+
+The `vsphere-cloud-provider` charm allows **Charmed Kubernetes** to connect to the vSphere API 
+via the out-of-tree cloud provider. This allow your cluster to manage parts of the vSphere infrastructure, 
+such as virtual disks.
 
 ## vSphere integrator
 
 The `vsphere-integrator` charm simplifies working with **Charmed Kubernetes** on
 vSphere servers. Using the credentials provided to **Juju**, it acts as a proxy between
-Charmed Kubernetes and the underlying cloud, granting permissions to
-dynamically create, for example, storage.
+Charmed Kubernetes and the underlying cloud. This charm integrates with the `vsphere-cloud-provider` 
+charm to share the credentials required for its operation.
 
 ### Model configuration
 
@@ -42,23 +48,31 @@ juju model-config datastore=mydatastore primary-network=mynetwork
 ### Installing
 
 If you install **Charmed Kubernetes** [using the Juju bundle][install],
-you can add the vsphere-integrator at the same time by using the following
+you can add both `vsphere-cloud-provider` and `vsphere-integrator` at the same time by using the following
 overlay file ([download it here][asset-vsphere-overlay]):
 
 ```yaml
 description: Charmed Kubernetes overlay to add native vSphere support.
 applications:
+  kubernetes-control-plane:
+    options:
+      allow-privileged: "true"
   vsphere-integrator:
-    annotations:
-      gui-x: "600"
-      gui-y: "300"
     charm: vsphere-integrator
     num_units: 1
     trust: true
+  vsphere-cloud-provider:
+    charm: vsphere-cloud-provider
 relations:
-  - ['vsphere-integrator', 'kubernetes-control-plane']
-  - ['vsphere-integrator', 'kubernetes-worker']
-  ```
+- - vsphere-cloud-provider:certificates
+  - easyrsa:client
+- - vsphere-cloud-provider:kube-control
+  - kubernetes-control-plane:kube-control
+- - vsphere-cloud-provider:external-cloud-provider
+  - kubernetes-control-plane:external-cloud-provider
+- - vsphere-cloud-provider:vsphere-integration
+  - vsphere-integrator:clients
+```
 
 To use this overlay with the **Charmed Kubernetes** bundle, it is specified
 during deploy like this:
@@ -76,7 +90,7 @@ juju scp kubernetes-control-plane/0:config ~/.kube/config
 <div class="p-notification--caution is-inline">
   <div class="p-notification__content">
     <span class="p-notification__title">Resource usage:</span>
-    <p class="p-notification__message">By relating to this charm, other charms can directly allocate resources, such as managed disks and load balancers, which could lead to cloud charges and
+    <p class="p-notification__message">By relating to these charms, other charms can directly allocate resources, such as managed disks and load balancers, which could lead to cloud charges and
     count against quotas. Because these resources are not managed by Juju, they
     will not be automatically deleted when the models or applications are
     destroyed, nor will they show up in Juju's status or GUI. It is therefore up
@@ -129,22 +143,20 @@ back to the credential data it received via `juju trust`.
 
 ## Storage
 
-The vSphere integrator can make use of vSphere-backed storage for Kubernetes.
+The vSphere charms can make use of vSphere-backed storage for Kubernetes.
 The steps below create a busybox pod with a persistent volume claim backed by
 vSphere's PersistentDisk as an example.
 
 
-### 1. Create a storage class using the `kubernetes.io/vsphere-volume` provisioner:
+### 1. Create a storage class using the `csi.vsphere.vmware.com` provisioner:
 
 ```bash
 kubectl create -f - <<EOY
-apiVersion: storage.k8s.io/v1
 kind: StorageClass
+apiVersion: storage.k8s.io/v1
 metadata:
   name: mystorage
-provisioner: kubernetes.io/vsphere-volume
-parameters:
-  diskformat: zeroedthick
+provisioner: csi.vsphere.vmware.com
 EOY
 ```
 
@@ -194,15 +206,15 @@ spec:
 EOY
 ```
 
-For more configuration options and details of the permissions which the integrator uses,
-please see the [vSphere integrator charm page][vsphere-integrator].
+For more configuration options and details of the permissions which the cloud provider uses,
+please see the [vSphere Cloud Provider charm page][vsphere-cloud-provider].
 
 <!-- LINKS -->
 
 [asset-vsphere-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/overlays/vsphere-overlay.yaml
 
 [storage]: /kubernetes/docs/storage
-[vsphere-integrator]: https://charmhub.io/vsphere-integrator/docs
+[vsphere-cloud-provider]: https://charmhub.io/vsphere-cloud-provider/docs
 [vsphere-juju]: https://juju.is/docs/olm/vmware-vsphere
 [install]: /kubernetes/docs/install-manual
 [vmware documentation]: https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/existing.html


### PR DESCRIPTION
## Changes
Now that the vSphere in-tree provider has been deprecated, we should advise the users to use the new out-of-tree provider (`vsphere-cloud-provider`). 