### PR TITLE
1.26+ck2 release notes

### DIFF
--- a/pages/k8s/1.25/release-notes.md
+++ b/pages/k8s/1.25/release-notes.md
@@ -14,13 +14,13 @@ toc: False
 ---
 
 
-# 1.25+ck2 Bugfix release
+# 1.25+ck3 Bugfix release
 
-### December 1, 2022
+### December 1, 2022 - `charmed-kubernetes --channel 1.25/stable`
 
-## Additions
+## Fixes
 
-Notable additions in this release include:
+Notable fixes in this release include:
 
 - Kubernetes Control Plane [LP#1991957](https://bugs.launchpad.net/bugs/1991957)
 
@@ -31,31 +31,6 @@ Notable additions in this release include:
 
   Resolves an issue deploying the charm into a jammy lxd container, where a missing
   path definition to `/etc/fstab` interrupted the configure kubelet hook.
-
-
-# 1.25 Point Release
-
-### October ??, 2022
-
-## Additions
-
-Notable additions in this release include:
-
-- AwsEbs in Kubernetes-Control-Plane / Kubernetes-Worker [LP#1988186](https://bugs.launchpad.net/bugs/1988186)
-
-  With the pinning of [CSIMigrationAWS=True](https://github.com/kubernetes/kubernetes/pull/111479) in 
-  Kubernetes 1.25, the charm must not allow these to be set `False`.  This means that in-tree storage
-  provided by AWS is only supported in 1.25 and beyond with an [out-of-tree deployment](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/).
-
-  [aws-k8s-storage](https://charmhub.io/aws-k8s-storage) provides the out-of-tree deployment as a charm.
-
-- GCE in Kubernetes-Control-Plane / Kubernetes-Worker [LP#1988186](https://bugs.launchpad.net/bugs/1988186)
-
-  With the pinning of [CSIMigrationGCE=True](https://github.com/kubernetes/kubernetes/pull/111301) in 
-  Kubernetes 1.25, the charm must not allow these to be set `False`.  This means that in-tree storage
-  provided by GCE is only supported in 1.25 and beyond with an [out-of-tree deployment](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver).
-
-  [gcp-k8s-storage](https://charmhub.io/gcp-k8s-storage) provides the out-of-tree deployment as a charm.
 
 
 # 1.25+ck2 Bugfix release 
@@ -88,6 +63,21 @@ Notable fixes in this release include:
 
   Bug is marked resolved in 1.25+ck2, but was available in the gcp-integrator charm at time of 1.25+ck1 release.
 
+- AwsEbs in Kubernetes-Control-Plane / Kubernetes-Worker [LP#1988186](https://bugs.launchpad.net/bugs/1988186)
+
+  With the pinning of [CSIMigrationAWS=True](https://github.com/kubernetes/kubernetes/pull/111479) in 
+  Kubernetes 1.25, the charm must not allow these to be set `False`.  This means that in-tree storage
+  provided by AWS is only supported in 1.25 and beyond with an [out-of-tree deployment](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/).
+
+  [aws-k8s-storage](https://charmhub.io/aws-k8s-storage) provides the out-of-tree deployment as a charm.
+
+- GCE in Kubernetes-Control-Plane / Kubernetes-Worker [LP#1988186](https://bugs.launchpad.net/bugs/1988186)
+
+  With the pinning of [CSIMigrationGCE=True](https://github.com/kubernetes/kubernetes/pull/111301) in 
+  Kubernetes 1.25, the charm must not allow these to be set `False`.  This means that in-tree storage
+  provided by GCE is only supported in 1.25 and beyond with an [out-of-tree deployment](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver).
+
+  [gcp-k8s-storage](https://charmhub.io/gcp-k8s-storage) provides the out-of-tree deployment as a charm.
 
 A list of bug fixes and other minor feature updates in this release can be found at
 [the launchpad milestone page for 1.25+ck2](https://launchpad.net/charmed-kubernetes/+milestone/1.25+ck2).

--- a/pages/k8s/1.26/release-notes.md
+++ b/pages/k8s/1.26/release-notes.md
@@ -14,9 +14,34 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+# 1.26+ck2 Bugfix release
+
+### February 27, 2023 - `charmed-kubernetes --channel 1.26/stable`
+
+## Fixes
+
+Notable fixes in this release include:
+
+- Kubernetes Autoscaler [LP#2007182](https://bugs.launchpad.net/charm-kubernetes-autoscaler/+bug/2007182)
+
+  Update the autoscaler image for use with newer Juju controllers.
+
+- Etcd [LP#1997531](https://bugs.launchpad.net/charm-etcd/+bug/1997531)
+
+  Restrict non-root access to etcd snap data directory.
+
+- Kubernetes Control Plane [LP#2007174](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2007174)
+
+  Restrict non-root access to the script responsible for synchronizing control-plane leader files to followers.
+
+- Bundles [LP#](https://bugs.launchpad.net/charmed-kubernetes-bundles/+bug/2008582)
+
+  Add missing bundle overlays for AWS/GCE cloud storage providers.
+
+
 # 1.26+ck1 Bugfix release
 
-### January 16, 2022 - `charmed-kubernetes --channel 1.26/stable` 
+### January 16, 2023 - `charmed-kubernetes --channel 1.26/stable`
 
 The release bundle can also be [downloaded here](https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.26/bundle.yaml).
 


### PR DESCRIPTION
I noticed the 1.25 release notes seemed to have a couple bugs hanging out in limbo between ck2 and ck3. Confirmed they actually went out with ck2 and adjusted the page accordingly.

This PR also adds the 1.26+ck2 release notes, which has passed validation and will be marked stable on Feb 27.