### PR TITLE
etcd updates

### DIFF
--- a/_data/sidebars/k8smain-sidebar.yml
+++ b/_data/sidebars/k8smain-sidebar.yml
@@ -23,16 +23,16 @@ entries:
     items:
 
       
+    - title: '1.27'
+      url: /1.27/components
+      output: web, pdf
+
     - title: '1.26'
       url: /1.26/components
       output: web, pdf
 
     - title: '1.25'
       url: /1.25/components
-      output: web, pdf
-
-    - title: '1.24'
-      url: /1.24/components
       output: web, pdf
 
     - title: Version info

--- a/_data/sidebars/k8smain-sidebar.yml
+++ b/_data/sidebars/k8smain-sidebar.yml
@@ -22,7 +22,6 @@ entries:
     type: section
     items:
 
-      
     - title: '1.27'
       url: /1.27/components
       output: web, pdf

--- a/pages/k8s/1.23/upgrading.md
+++ b/pages/k8s/1.23/upgrading.md
@@ -162,50 +162,20 @@ As previously, wait between running the action on sucessive units to allow pods 
 
 As **etcd** manages critical data for the cluster, it is advisable to create a snapshot of
 this data before running an upgrade. This is covered in more detail in the
-[documentation on backups][backups], but the basic steps are:
+[documentation on backups][backups] (including how to restore snapshots in case of
+problems).
 
-#### 1. Run the snapshot action on the charm
-
-```bash
-juju run-action etcd/0 snapshot --wait
-```
-You should see confirmation of the snapshot being created, and the command needed to download the snapshot
-_from the **etcd** unit_. See the following truncated, example output:
-
-```
-...
-copy:
-      cmd: juju scp etcd/40:/home/ubuntu/etcd-snapshots/etcd-snapshot-2020-11-18-21.37.11.tar.gz
-        .
-...
-```
-
-#### 2. Fetch a local copy of the snapshot
-
-You can use the `juju scp` command from the output above to download a local copy. For example:
-
-```
-juju scp etcd/40:/home/ubuntu/etcd-snapshots/etcd-snapshot-2020-11-18-21.37.11.tar.gz .
-```
-
-Substitute in your own etcd unit number and filename, or copy and paste the command from the previous
-output. Remember to add the ` .` at the end to copy to your local directory!
-
-#### 3. Upgrade the charm
-
-You can now upgrade the **etcd** charm:
+Upgrade the charm with the command:
 
 ```bash
 juju upgrade-charm etcd
 ```
 
-#### 4. Upgrade etcd
-
 To upgrade **etcd** itself, you will need to set the **etcd** charm's channel
 config.
 
 To determine the correct channel, go to the
-[Supported Versions][supported-versions] page and check the relevant
+[releases section of the bundle repository][bundle-repo] page and check the relevant
 **Charmed Kubernetes** bundle. Within the bundle, you should see which channel
 the **etcd** charm is configured to use.
 
@@ -492,6 +462,7 @@ kube-system                       monitoring-influxdb-grafana-v4-65cc9bb8c8-mwvc
 [validation]: /kubernetes/docs/validation
 [supported-versions]: /kubernetes/docs/supported-versions
 [juju-controller-upgrade]: https://juju.is/docs/olm/upgrade-models
+[bundle-repo]: https://github.com/charmed-kubernetes/bundle/tree/main/releases
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">

--- a/pages/k8s/1.24/upgrading.md
+++ b/pages/k8s/1.24/upgrading.md
@@ -94,56 +94,24 @@ the steps outlined in [this section of the upgrade notes][docker2containerd].
 
 As **etcd** manages critical data for the cluster, it is advisable to create a snapshot of
 this data before running an upgrade. This is covered in more detail in the
-[documentation on backups][backups], but the basic steps are:
+[documentation on backups][backups] (including how to restore snapshots in case of
+problems).
 
-#### 1. Run the snapshot action on the charm
-
-```bash
-juju run-action etcd/0 snapshot --wait
-```
-You should see confirmation of the snapshot being created, and the command needed to download the snapshot
-_from the **etcd** unit_. See the following truncated, example output:
-
-```
-...
-copy:
-      cmd: juju scp etcd/40:/home/ubuntu/etcd-snapshots/etcd-snapshot-2020-11-18-21.37.11.tar.gz
-        .
-...
-```
-
-#### 2. Fetch a local copy of the snapshot
-
-You can use the `juju scp` command from the output above to download a local copy. For example:
-
-```
-juju scp etcd/40:/home/ubuntu/etcd-snapshots/etcd-snapshot-2020-11-18-21.37.11.tar.gz .
-```
-
-Substitute in your own etcd unit number and filename, or copy and paste the command from the previous
-output. Remember to add the ` .` at the end to copy to your local directory!
-
-
-#### 3. Upgrade the charm
-
-You can now upgrade the **etcd** charm:
+Upgrade the charm with the command:
 
 ```bash
-juju upgrade-charm etcd --switch ch:etcd --channel 1.24/stable
+juju upgrade-charm etcd
 ```
-
-#### 4. Upgrade etcd
 
 To upgrade **etcd** itself, you will need to set the **etcd** charm's channel
 config.
 
-For 1.24, the etcd charm is configured to use the 3.4/stable channel as in the previous release, but it is worth checking the configuration:
+To determine the correct channel, go to the
+[releases section of the bundle repository][bundle-repo] page and check the relevant
+**Charmed Kubernetes** bundle. Within the bundle, you should see which channel
+the **etcd** charm is configured to use.
 
-```bash
-juju config etcd
-```
-
-If you need to update it, you can set the **etcd** charm's channel config:
+Once you know the correct channel, set the **etcd** charm's channel config:
 
 ```bash
 juju config etcd channel=3.4/stable
@@ -429,6 +397,7 @@ kube-system                       monitoring-influxdb-grafana-v4-65cc9bb8c8-mwvc
 [supported-versions]: /kubernetes/docs/supported-versions
 [docker2containerd]: /kubernetes/docs/upgrade-notes#1.15
 [juju-controller-upgrade]: https://juju.is/docs/olm/upgrade-models
+[bundle-repo]: https://github.com/charmed-kubernetes/bundle/tree/main/releases
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">

--- a/pages/k8s/1.25/upgrading.md
+++ b/pages/k8s/1.25/upgrading.md
@@ -87,51 +87,20 @@ juju upgrade-charm containerd
 
 As **etcd** manages critical data for the cluster, it is advisable to create a snapshot of
 this data before running an upgrade. This is covered in more detail in the
-[documentation on backups][backups], but the basic steps are:
+[documentation on backups][backups] (including how to restore snapshots in case of
+problems).
 
-#### 1. Run the snapshot action on the charm
-
-```bash
-juju run-action etcd/0 snapshot --wait
-```
-You should see confirmation of the snapshot being created, and the command needed to
-download the snapshot _from the **etcd** unit_. See the following truncated, example output:
-
-```
-...
-copy:
-      cmd: juju scp etcd/40:/home/ubuntu/etcd-snapshots/etcd-snapshot-2020-11-18-21.37.11.tar.gz
-        .
-...
-```
-
-#### 2. Fetch a local copy of the snapshot
-
-You can use the `juju scp` command from the output above to download a local copy. For example:
-
-```
-juju scp etcd/40:/home/ubuntu/etcd-snapshots/etcd-snapshot-2020-11-18-21.37.11.tar.gz .
-```
-
-Substitute in your own etcd unit number and filename, or copy and paste the command from the previous
-output. Remember to add the ` .` at the end to copy to your local directory!
-
-
-#### 3. Upgrade the charm
-
-You can now upgrade the **etcd** charm:
+Upgrade the charm with the command:
 
 ```bash
 juju upgrade-charm etcd
 ```
 
-#### 4. Upgrade etcd
-
 To upgrade **etcd** itself, you will need to set the **etcd** charm's channel
 config.
 
 To determine the correct channel, go to the
-[Supported Versions][supported-versions] page and check the relevant
+[releases section of the bundle repository][bundle-repo] page and check the relevant
 **Charmed Kubernetes** bundle. Within the bundle, you should see which channel
 the **etcd** charm is configured to use.
 
@@ -368,6 +337,7 @@ It is recommended that you run a [cluster validation][validation] to ensure that
 [supported-versions]: /kubernetes/docs/supported-versions
 [juju-controller-upgrade]: https://juju.is/docs/olm/upgrade-models
 [inclusive-naming]: /kubernetes/docs/inclusive-naming
+[bundle-repo]: https://github.com/charmed-kubernetes/bundle/tree/main/releases
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">

--- a/pages/k8s/1.26/upgrading.md
+++ b/pages/k8s/1.26/upgrading.md
@@ -110,51 +110,20 @@ juju upgrade-charm containerd
 
 As **etcd** manages critical data for the cluster, it is advisable to create a snapshot of
 this data before running an upgrade. This is covered in more detail in the
-[documentation on backups][backups], but the basic steps are:
+[documentation on backups][backups] (including how to restore snapshots in case of
+problems).
 
-#### 1. Run the snapshot action on the charm
-
-```bash
-juju run-action etcd/0 snapshot --wait
-```
-You should see confirmation of the snapshot being created, and the command needed to
-download the snapshot _from the **etcd** unit_. See the following truncated, example output:
-
-```
-...
-copy:
-      cmd: juju scp etcd/40:/home/ubuntu/etcd-snapshots/etcd-snapshot-2020-11-18-21.37.11.tar.gz
-        .
-...
-```
-
-#### 2. Fetch a local copy of the snapshot
-
-You can use the `juju scp` command from the output above to download a local copy. For example:
-
-```
-juju scp etcd/40:/home/ubuntu/etcd-snapshots/etcd-snapshot-2020-11-18-21.37.11.tar.gz .
-```
-
-Substitute in your own etcd unit number and filename, or copy and paste the command from the previous
-output. Remember to add the ` .` at the end to copy to your local directory!
-
-
-#### 3. Upgrade the charm
-
-You can now upgrade the **etcd** charm:
+Upgrade the charm with the command:
 
 ```bash
 juju upgrade-charm etcd
 ```
 
-#### 4. Upgrade etcd
-
 To upgrade **etcd** itself, you will need to set the **etcd** charm's channel
 config.
 
 To determine the correct channel, go to the
-[Supported Versions][supported-versions] page and check the relevant
+[releases section of the bundle repository][bundle-repo] page and check the relevant
 **Charmed Kubernetes** bundle. Within the bundle, you should see which channel
 the **etcd** charm is configured to use.
 
@@ -163,6 +132,7 @@ Once you know the correct channel, set the **etcd** charm's channel config:
 ```bash
 juju config etcd channel=3.4/stable
 ```
+
 
 ### Upgrading additional components
 
@@ -380,6 +350,7 @@ It is recommended that you run a [cluster validation][validation] to ensure that
 [supported-versions]: /kubernetes/docs/supported-versions
 [juju-controller-upgrade]: https://juju.is/docs/olm/upgrade-models
 [inclusive-naming]: /kubernetes/docs/inclusive-naming
+[bundle-repo]: https://github.com/charmed-kubernetes/bundle/tree/main/releases
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">

--- a/pages/k8s/1.27/upgrading.md
+++ b/pages/k8s/1.27/upgrading.md
@@ -112,51 +112,20 @@ juju upgrade-charm containerd
 
 As **etcd** manages critical data for the cluster, it is advisable to create a snapshot of
 this data before running an upgrade. This is covered in more detail in the
-[documentation on backups][backups], but the basic steps are:
+[documentation on backups][backups] (including how to restore snapshots in case of
+problems).
 
-#### 1. Run the snapshot action on the charm
-
-```bash
-juju run-action etcd/0 snapshot --wait
-```
-You should see confirmation of the snapshot being created, and the command needed to
-download the snapshot _from the **etcd** unit_. See the following truncated, example output:
-
-```
-...
-copy:
-      cmd: juju scp etcd/40:/home/ubuntu/etcd-snapshots/etcd-snapshot-2020-11-18-21.37.11.tar.gz
-        .
-...
-```
-
-#### 2. Fetch a local copy of the snapshot
-
-You can use the `juju scp` command from the output above to download a local copy. For example:
-
-```
-juju scp etcd/40:/home/ubuntu/etcd-snapshots/etcd-snapshot-2020-11-18-21.37.11.tar.gz .
-```
-
-Substitute in your own etcd unit number and filename, or copy and paste the command from the previous
-output. Remember to add the ` .` at the end to copy to your local directory!
-
-
-#### 3. Upgrade the charm
-
-You can now upgrade the **etcd** charm:
+Upgrade the charm with the command:
 
 ```bash
 juju upgrade-charm etcd
 ```
 
-#### 4. Upgrade etcd
-
 To upgrade **etcd** itself, you will need to set the **etcd** charm's channel
 config.
 
 To determine the correct channel, go to the
-[Supported Versions][supported-versions] page and check the relevant
+[releases section of the bundle repository][bundle-repo] page and check the relevant
 **Charmed Kubernetes** bundle. Within the bundle, you should see which channel
 the **etcd** charm is configured to use.
 
@@ -382,6 +351,7 @@ It is recommended that you run a [cluster validation][validation] to ensure that
 [blue-green]: https://martinfowler.com/bliki/BlueGreenDeployment.html
 [validation]: /kubernetes/docs/validation
 [supported-versions]: /kubernetes/docs/supported-versions
+[bundle-repo]: https://github.com/charmed-kubernetes/bundle/tree/main/releases
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">

--- a/pages/k8s/backups.md
+++ b/pages/k8s/backups.md
@@ -26,7 +26,7 @@ documentation for details.
 <div class="p-notification--caution is-inline">
   <div markdown="1" class="p-notification__content">
     <span class="p-notification__title">Warning:</span>
-    <p class="p-notification__message">Snapshots can only be restored on the **same version of etcd**.</p>
+    <p class="p-notification__message">Snapshots can only be restored on the **same major version of etcd**.</p>
   </div>
 </div>
 

--- a/pages/k8s/backups.md
+++ b/pages/k8s/backups.md
@@ -17,8 +17,9 @@ The state of your **Kubernetes** cluster is kept in the **etcd** datastore.
 This page shows how to backup and restore the etcd included in
 **Charmed Kubernetes**.
 
-Backing up application specific data, normally stored in a persistent volume, is not currently supported by native Kubernetes. Various third party solutions are available -
-please refer to their own documentation for details.
+Backing up application specific data, normally stored in a persistent volume, is not currently supported
+by native Kubernetes. Various third party solutions are available - please refer to their own
+documentation for details.
 
 ## Creating an **etcd** snapshot
 
@@ -29,7 +30,8 @@ please refer to their own documentation for details.
   </div>
 </div>
 
-**etcd** is a distributed key/value store. To create a snapshot, all that is required is to run the `snapshot` action on one of the units running **etcd**:
+**etcd** is a distributed key/value store. To create a snapshot, all that is required is to run the
+`snapshot` action on one of the units running **etcd**:
 
 ```bash
 juju run etcd/0 snapshot keys-version=v3
@@ -42,10 +44,10 @@ unit-etcd-0:
  id: 3d6a505e-07d7-4697-8471-60156f87b1b4
  results:
    copy:
-     cmd: juju scp etcd/0:/home/ubuntu/etcd-snapshots/etcd-snapshot-2018-09-26-18.04.02.tar.gz
+     cmd: juju scp etcd/0:/home/ubuntu/etcd-snapshots/etcd-snapshot-2023-04-26-18.04.02.tar.gz
        .
    snapshot:
-     path: /home/ubuntu/etcd-snapshots/etcd-snapshot-2018-09-26-18.04.02.tar.gz
+     path: /home/ubuntu/etcd-snapshots/etcd-snapshot-2023-04-26-18.04.02.tar.gz
      sha256: e85ae4d49b6a889de2063031379ab320cc8f09b6e328cdff2fb9179fc641eee9
      size: 68K
      version: |-
@@ -53,24 +55,26 @@ unit-etcd-0:
        API version: 2
  status: completed
  timing:
-   completed: 2018-09-26 18:04:04 +0000 UTC
-   enqueued: 2018-09-26 18:04:04 +0000 UTC
-   started: 2018-09-26 18:04:03 +0000 UTC
+   completed: 2023-04-26 18:04:04 +0000 UTC
+   enqueued: 2023-04-26 18:04:04 +0000 UTC
+   started: 2023-04-26 18:04:03 +0000 UTC
  unit: etcd/0
 ```
 
 This path/filename relates to the unit where the action was run. As we will likely want to use the snapshot on a different unit, we should fetch the snapshot to the local machine. The command to perform this is also helpfully supplied in the `copy` section of the output (see above):
 
 ```bash
-  juju scp etcd/0:/home/ubuntu/etcd-snapshots/etcd-snapshot-2018-09-26-18.04.02.tar.gz .
+  juju scp etcd/0:/home/ubuntu/etcd-snapshots/etcd-snapshot-2023-04-26-18.04.02.tar.gz .
 ```
 
 It is also wise to check the sha256 checksum of the file you have copied
 against the value in the previous output:
 
 ```bash
-sha256sum etcd-snapshot-2018-09-26-18.04.02.tar.gz
+sha256sum etcd-snapshot-2023-04-26-18.04.02.tar.gz
 ```
+
+Note that some applications (e.g. flannel) may store data using the older 'v2' format. In this case you will need to repeat the snapshot procedure above for ***both*** 'keys-version=v3' and 'keys-version=v2'
 
 ## Restoring a snapshot
 
@@ -94,7 +98,7 @@ The `--config` option is required to specify the same channel of etcd as the ori
 Next we upload and identify the snapshot file to this new unit:
 
 ```bash
-juju attach-resource new-etcd snapshot=./etcd-snapshot-2018-09-26-18.04.02.tar.gz
+juju attach-resource new-etcd snapshot=./etcd-snapshot-2023-04-26-18.04.02.tar.gz
 ```
 
 Then run the restore action:
@@ -102,6 +106,8 @@ Then run the restore action:
 ```bash
 juju run new-etcd/0 restore
 ```
+
+If you have snapshots for both v2 and v3 data, you should repeat the last two steps and restore the additional snapshot at this time.
 
 Once the restore action has finished, you should see output confirming that the operation is `completed`. The new etcd application will need to be connected to the rest of the deployment:
 
@@ -134,9 +140,9 @@ unit-new-etcd-0:
         cluster is healthy
   status: completed
   timing:
-    completed: 2018-10-26 15:16:33 +0000 UTC
-    enqueued: 2018-10-26 15:16:32 +0000 UTC
-    started: 2018-10-26 15:16:33 +0000 UTC
+    completed: 2023-04-26 23:16:33 +0000 UTC
+    enqueued: 2023-04-26 23:16:32 +0000 UTC
+    started: 2023-04-26 23:16:33 +0000 UTC
   unit: new-etcd/0
 ```
 


### PR DESCRIPTION
- Upgrade pages point to backups page for snapshot and restore of etcd
- backups page adds detail about v2 and v3 data
