### PR TITLE
Quick fix MetalLB links for 1.27

### DIFF
--- a/pages/k8s/metallb.md
+++ b/pages/k8s/metallb.md
@@ -94,7 +94,7 @@ to use the Kubernetes API to create the necessary resources to make MetalLB
 work. You can apply the manifest using `kubectl`:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/charmed-kubernetes/metallb-operator/main/docs/rbac-permissions-operators.yaml
+kubectl apply -f https://raw.githubusercontent.com/charmed-kubernetes/metallb-operator/release_1.27/docs/rbac-permissions-operators.yaml
 ```
 
 Be aware that the manifest has to refer to the namespace in which MetalLB is
@@ -140,7 +140,7 @@ To test your deployment of MetalLB, you can use the [microbot manifest][] to
 deploy a simple webapp with a service type of `LoadBalancer`:
 
 ```bash
-wget https://raw.githubusercontent.com/charmed-kubernetes/metallb-operator/master/docs/example-microbot-lb.yaml
+wget https://raw.githubusercontent.com/charmed-kubernetes/metallb-operator/release_1.27/docs/example-microbot-lb.yaml
 kubectl apply -f example-microbot-lb.yaml
 kubectl get service microbot-lb
 ```
@@ -162,10 +162,10 @@ kubectl delete -f example-microbot-lb.yaml
 [metallb]: https://metallb.universe.tf
 [arp]: https://tools.ietf.org/html/rfc826
 [bgp]: https://tools.ietf.org/html/rfc1105
-[rbac-manifest]: https://raw.githubusercontent.com/charmed-kubernetes/metallb-operator/master/docs/rbac-permissions-operators.yaml
+[rbac-manifest]: https://raw.githubusercontent.com/charmed-kubernetes/metallb-operator/release_1.27/docs/rbac-permissions-operators.yaml
 [upstream manifests]: https://github.com/metallb/metallb/tree/main/config/manifests
 [configmap]: https://metallb.universe.tf/configuration/#bgp-configuration
-[microbot manifest]: https://raw.githubusercontent.com/charmed-kubernetes/metallb-operator/master/docs/example-microbot-lb.yaml
+[microbot manifest]: https://raw.githubusercontent.com/charmed-kubernetes/metallb-operator/release_1.27/docs/example-microbot-lb.yaml
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">


### PR DESCRIPTION
Quick fix for https://github.com/charmed-kubernetes/kubernetes-docs/issues/784

The MetalLB docs will need to be reworked for CK 1.28, so, these links probably won't be in the docs much longer.