### PR TITLE
Set charm upgrade channels during the upgrade steps

### DIFF
--- a/pages/k8s/1.26/upgrading.md
+++ b/pages/k8s/1.26/upgrading.md
@@ -103,7 +103,7 @@ By default, Versions 1.15 and later use Containerd as the container
 runtime. This subordinate charm can be upgraded with the command:
 
 ```bash
-juju upgrade-charm containerd
+juju refresh containerd --channel=1.26/stable
 ```
 
 ### Upgrading etcd
@@ -116,7 +116,7 @@ problems).
 Upgrade the charm with the command:
 
 ```bash
-juju upgrade-charm etcd
+juju refresh etcd --channel=1.26/stable
 ```
 
 To upgrade **etcd** itself, you will need to set the **etcd** charm's channel
@@ -136,18 +136,18 @@ juju config etcd channel=3.4/stable
 
 ### Upgrading additional components
 
-The other infrastructure applications can be upgraded by running the `upgrade-charm`
+The other infrastructure applications can be upgraded by running the `refresh`
 command:
 
 ```bash
-juju upgrade-charm easyrsa
+juju refresh easyrsa --channel=1.26/stable
 ```
 
 Any other infrastructure charms should be upgraded in a similar way. For
 example, if you are using the flannel CNI:
 
 ```bash
-juju upgrade-charm flannel
+juju refresh flannel --channel=1.26/stable
 ```
 
 <div class="p-notification--caution">
@@ -187,7 +187,7 @@ continuity this upgrade should precede any upgrades to the **Kubernetes** master
 worker units.
 
 ```bash
-juju upgrade-charm kubeapi-load-balancer
+juju refresh kubeapi-load-balancer --channel=1.26/stable
 ```
 
 The load balancer itself is based on NGINX, and the version reported by `juju status` is
@@ -204,13 +204,13 @@ substitute `kubernetes-control-plane`for `kubernetes-master`in the following com
 To start upgrading the Kubernetes master units, first upgrade the charm:
 
 ```bash
-juju upgrade-charm kubernetes-control-plane 
+juju refresh kubernetes-control-plane --channel=1.26/stable
 ```
 
-Once the charm has been upgraded, it can be configured to select the desired **Kubernetes** channel, which takes the form `Major.Minor/risk-level`. This is then passed as a configuration option to the charm. So, for example, to select the stable 1.25 version of **Kubernetes**, you would enter:
+Once the charm has been upgraded, it can be configured to select the desired **Kubernetes** channel, which takes the form `Major.Minor/risk-level`. This is then passed as a configuration option to the charm. So, for example, to select the stable 1.26 version of **Kubernetes**, you would enter:
 
 ```bash
-juju config kubernetes-control-plane channel=1.25/stable
+juju config kubernetes-control-plane channel=1.26/stable
 ```
 
 If you wanted to try a release candidate for 1.26, the channel would be `1.26/candidate`.
@@ -255,13 +255,13 @@ Both methods are outlined below. The blue-green method is recommended for produc
 To begin, upgrade the kubernetes-worker charm itself:
 
 ```bash
-juju upgrade-charm kubernetes-worker
+juju refresh kubernetes-worker --channel=1.26/stable
 ```
 
 Next, run the command to configure the workers for the version of Kubernetes you wish to run (as you did previously for the master units). For example:
 
 ```bash
-juju config kubernetes-worker channel=1.19/stable
+juju config kubernetes-worker channel=1.26/stable
 ```
 
 Now add additional units of the kubernetes-worker. You should add as many units as you are replacing. For example, to add three additional units:
@@ -307,13 +307,13 @@ A variation on this method is to add, pause, remove  and recycle units one at a 
 To proceed with an in-place upgrade, first upgrade the charm itself:
 
 ```bash
-juju upgrade-charm kubernetes-worker
+juju refresh kubernetes-worker --channel=1.26/stable
 ```
 
 Next, run the command to configure the workers for the version of **Kubernetes** you wish to run (as you did previously for the master units). For example:
 
 ```bash
-juju config kubernetes-worker channel=1.12/stable
+juju config kubernetes-worker channel=1.26/stable
 ```
 
 All the units can now be upgraded by running the `upgrade` action on each one:

--- a/pages/k8s/1.27/upgrading.md
+++ b/pages/k8s/1.27/upgrading.md
@@ -308,7 +308,7 @@ A variation on this method is to add, pause, remove  and recycle units one at a 
 To proceed with an in-place upgrade, first upgrade the charm itself:
 
 ```bash
-juju refresh kubernetes-worker
+juju refresh kubernetes-worker --channel=1.27/stable
 ```
 
 Next, run the command to configure the workers for the version of **Kubernetes** you wish to run (as you did previously for the master units). For example:

--- a/pages/k8s/1.27/upgrading.md
+++ b/pages/k8s/1.27/upgrading.md
@@ -105,7 +105,7 @@ By default, Versions 1.15 and later use Containerd as the container
 runtime. This subordinate charm can be upgraded with the command:
 
 ```bash
-juju upgrade-charm containerd
+juju refresh containerd --channel=1.27/stable
 ```
 
 ### Upgrading etcd
@@ -118,7 +118,7 @@ problems).
 Upgrade the charm with the command:
 
 ```bash
-juju upgrade-charm etcd
+juju refresh etcd --channel=1.27/stable
 ```
 
 To upgrade **etcd** itself, you will need to set the **etcd** charm's channel
@@ -141,14 +141,14 @@ The other infrastructure applications can be upgraded by running the `upgrade-ch
 command:
 
 ```bash
-juju upgrade-charm easyrsa
+juju refresh easyrsa --channel=1.27/stable
 ```
 
 Any other infrastructure charms should be upgraded in a similar way. For
 example, if you are using the flannel CNI:
 
 ```bash
-juju upgrade-charm flannel
+juju refresh flannel --channel=1.27/stable
 ```
 
 <div class="p-notification--caution">
@@ -188,7 +188,7 @@ continuity this upgrade should precede any upgrades to the **Kubernetes** master
 worker units.
 
 ```bash
-juju upgrade-charm kubeapi-load-balancer
+juju refresh kubeapi-load-balancer --channel=1.27/stable
 ```
 
 The load balancer itself is based on NGINX, and the version reported by `juju status` is
@@ -205,13 +205,13 @@ substitute `kubernetes-control-plane`for `kubernetes-master`in the following com
 To start upgrading the Kubernetes master units, first upgrade the charm:
 
 ```bash
-juju upgrade-charm kubernetes-control-plane 
+juju refresh kubernetes-control-plane --channel=1.27/stable
 ```
 
 Once the charm has been upgraded, it can be configured to select the desired **Kubernetes** channel, which takes the form `Major.Minor/risk-level`. This is then passed as a configuration option to the charm. So, for example, to select the stable 1.25 version of **Kubernetes**, you would enter:
 
 ```bash
-juju config kubernetes-control-plane channel=1.25/stable
+juju config kubernetes-control-plane channel=1.27/stable
 ```
 
 If you wanted to try a release candidate for 1.26, the channel would be `1.26/candidate`.
@@ -256,13 +256,13 @@ Both methods are outlined below. The blue-green method is recommended for produc
 To begin, upgrade the kubernetes-worker charm itself:
 
 ```bash
-juju upgrade-charm kubernetes-worker
+juju refresh kubernetes-worker --channel=1.27/stable
 ```
 
 Next, run the command to configure the workers for the version of Kubernetes you wish to run (as you did previously for the master units). For example:
 
 ```bash
-juju config kubernetes-worker channel=1.19/stable
+juju config kubernetes-worker channel=1.27/stable
 ```
 
 Now add additional units of the kubernetes-worker. You should add as many units as you are replacing. For example, to add three additional units:
@@ -308,7 +308,7 @@ A variation on this method is to add, pause, remove  and recycle units one at a 
 To proceed with an in-place upgrade, first upgrade the charm itself:
 
 ```bash
-juju upgrade-charm kubernetes-worker
+juju refresh kubernetes-worker
 ```
 
 Next, run the command to configure the workers for the version of **Kubernetes** you wish to run (as you did previously for the master units). For example:

--- a/pages/k8s/1.28/upgrading.md
+++ b/pages/k8s/1.28/upgrading.md
@@ -342,7 +342,7 @@ A variation on this method is to add, pause, remove  and recycle units one at a 
 To proceed with an in-place upgrade, first upgrade the charm itself:
 
 ```bash
-juju refresh kubernetes-worker
+juju refresh kubernetes-worker --channel=1.28/stable
 ```
 
 Next, run the command to configure the workers for the version of **Kubernetes** you wish to run (as you did previously for the master units). For example:

--- a/pages/k8s/1.28/upgrading.md
+++ b/pages/k8s/1.28/upgrading.md
@@ -104,7 +104,7 @@ By default, Versions 1.15 and later use Containerd as the container
 runtime. This subordinate charm can be upgraded with the command:
 
 ```bash
-juju upgrade-charm containerd
+juju refresh containerd --channel=1.28/stable
 ```
 
 ### Upgrading etcd
@@ -117,7 +117,7 @@ problems).
 Upgrade the charm with the command:
 
 ```bash
-juju upgrade-charm etcd
+juju refresh etcd --channel=1.28/stable
 ```
 
 To upgrade **etcd** itself, you will need to set the **etcd** charm's channel
@@ -175,14 +175,14 @@ The other infrastructure applications can be upgraded by running the `upgrade-ch
 command:
 
 ```bash
-juju upgrade-charm easyrsa
+juju refresh easyrsa --channel=1.28/stable
 ```
 
 Any other infrastructure charms should be upgraded in a similar way. For
 example, if you are using the flannel CNI:
 
 ```bash
-juju upgrade-charm flannel
+juju refresh flannel --channel=1.28/stable
 ```
 
 <div class="p-notification--caution">
@@ -222,7 +222,7 @@ continuity this upgrade should precede any upgrades to the **Kubernetes** master
 worker units.
 
 ```bash
-juju upgrade-charm kubeapi-load-balancer
+juju refresh kubeapi-load-balancer --channel=1.28/stable
 ```
 
 The load balancer itself is based on NGINX, and the version reported by `juju status` is
@@ -239,13 +239,13 @@ substitute `kubernetes-control-plane`for `kubernetes-master`in the following com
 To start upgrading the Kubernetes master units, first upgrade the charm:
 
 ```bash
-juju upgrade-charm kubernetes-control-plane 
+juju refresh kubernetes-control-plane --channel=1.28/stable
 ```
 
-Once the charm has been upgraded, it can be configured to select the desired **Kubernetes** channel, which takes the form `Major.Minor/risk-level`. This is then passed as a configuration option to the charm. So, for example, to select the stable 1.25 version of **Kubernetes**, you would enter:
+Once the charm has been upgraded, it can be configured to select the desired **Kubernetes** channel, which takes the form `Major.Minor/risk-level`. This is then passed as a configuration option to the charm. So, for example, to select the stable 1.28 version of **Kubernetes**, you would enter:
 
 ```bash
-juju config kubernetes-control-plane channel=1.25/stable
+juju config kubernetes-control-plane channel=1.28/stable
 ```
 
 If you wanted to try a release candidate for 1.26, the channel would be `1.26/candidate`.
@@ -290,13 +290,13 @@ Both methods are outlined below. The blue-green method is recommended for produc
 To begin, upgrade the kubernetes-worker charm itself:
 
 ```bash
-juju upgrade-charm kubernetes-worker
+juju refresh kubernetes-worker --channel=1.28/stable
 ```
 
 Next, run the command to configure the workers for the version of Kubernetes you wish to run (as you did previously for the master units). For example:
 
 ```bash
-juju config kubernetes-worker channel=1.19/stable
+juju config kubernetes-worker channel=1.28/stable
 ```
 
 Now add additional units of the kubernetes-worker. You should add as many units as you are replacing. For example, to add three additional units:
@@ -342,13 +342,13 @@ A variation on this method is to add, pause, remove  and recycle units one at a 
 To proceed with an in-place upgrade, first upgrade the charm itself:
 
 ```bash
-juju upgrade-charm kubernetes-worker
+juju refresh kubernetes-worker
 ```
 
 Next, run the command to configure the workers for the version of **Kubernetes** you wish to run (as you did previously for the master units). For example:
 
 ```bash
-juju config kubernetes-worker channel=1.12/stable
+juju config kubernetes-worker channel=1.28/stable
 ```
 
 All the units can now be upgraded by running the `upgrade` action on each one:


### PR DESCRIPTION
Improve charm and snap upgrade docs to indicate how to step to a new charm channel.

* switch to using `juju refresh` since it is compatible in juju 2.9
* include `--channel` on charm refresh
* improve configuring the snap channels when configuring k8s-cp and k8s-workers

Fixes #796 