### PR TITLE
Add /sys/fs/bpf note for cnis on lxd which require a profile adjustment

### DIFF
--- a/pages/k8s/cni-overview.md
+++ b/pages/k8s/cni-overview.md
@@ -64,9 +64,9 @@ app is `ubuntu-control-plane-nodes` with the `ubuntu` charm.
 
 Both CNIs require access to the host `/sys/fs/bpf` and this can be exposed through the following profile adjustment
 ```bash
-    machine_app=ubuntu-control-plane-nodes
-    # Mount the host /sys/fs/bpf into the lxd containers of these machines
-    juju exec -a $machine_app -- 'sudo lxc profile edit default << EOF
+machine_app=ubuntu-control-plane-nodes
+# Mount the host /sys/fs/bpf into the lxd containers of these machines
+juju exec -a $machine_app -- 'sudo lxc profile edit default << EOF
 devices:
   sysfsbpf:
     path: /sys/fs/bpf
@@ -74,14 +74,14 @@ devices:
     type: disk
 EOF'
 
-    # Restart every container in the machine to update it's profile
-    readarray units < <(juju status $machine_app --format yaml | yq ".applications.$machine_app.units | keys" )
-    for unit in "${units[@]}"; do
-        juju exec -u $(echo $unit | yq .[0]) -- 'sudo lxc restart --all'
-    done
+# Restart every container in the machine to update it's profile
+readarray units < <(juju status $machine_app --format yaml | yq ".applications.$machine_app.units | keys" )
+for unit in "${units[@]}"; do
+    juju exec -u $(echo $unit | yq .[0]) -- 'sudo lxc restart --all'
+done
 
-    # wait for the cluster to settle
-    juju-wait
+# wait for the cluster to settle
+juju-wait
 ```
 
 <!-- LINKS -->

--- a/pages/k8s/cni-overview.md
+++ b/pages/k8s/cni-overview.md
@@ -63,7 +63,7 @@ as a subordinate unit of `kubernetes-control-plane` on a LXD. Those LXDs exist s
 app is `ubuntu-control-plane-nodes` with the `ubuntu` charm.
 
 Both CNIs require access to the host `/sys/fs/bpf` and this can be exposed through the following profile adjustment
-```shell
+```bash
     machine_app=ubuntu-control-plane-nodes
     # Mount the host /sys/fs/bpf into the lxd containers of these machines
     juju exec -a $machine_app -- 'sudo lxc profile edit default << EOF
@@ -73,12 +73,15 @@ devices:
     source: /sys/fs/bpf
     type: disk
 EOF'
-    units=$(juju status $machine_app --format yaml | yq ".applications.$machine_app.units | keys" )
+
     # Restart every container in the machine to update it's profile
-    for unit in $units; do
-        juju exec -u $unit -- 'sudo lxc restart --all'
+    readarray units < <(juju status $machine_app --format yaml | yq ".applications.$machine_app.units | keys" )
+    for unit in "${units[@]}"; do
+        juju exec -u $(echo $unit | yq .[0]) -- 'sudo lxc restart --all'
     done
-    juju-wait  # wait for the cluster to settle
+
+    # wait for the cluster to settle
+    juju-wait
 ```
 
 <!-- LINKS -->

--- a/pages/k8s/cni-overview.md
+++ b/pages/k8s/cni-overview.md
@@ -36,7 +36,8 @@ The currently supported base CNI solutions for **Charmed Kubernetes** are:
  -   [Kube-OVN][kube-ovn]
  -   [Tigera Secure EE][tigera]
 
-By default, **Charmed Kubernetes** will deploy the cluster using calico. To chose a different CNI provider, see the individual links above.
+By default, **Charmed Kubernetes** will deploy the cluster using Calico. To chose
+a different CNI provider, see the individual links above.
 
 The following CNI addons are also available:
  -   [Multus][multus]
@@ -52,14 +53,15 @@ Kubernetes, such a migration should be manageable with no downtime.
 
 ## CNI Requirements in a LXD
 
-More often, CNIs such as [cilium][] and [calico][] are requiring kernel features which make them more difficult to operate
-from within an LXD confinement. Charmed Kubernetes makes a best effort to operate CNIs, but admins should consider
-avoiding LXD as a choice to operate kubernetes-worker or kubernetes-control-plane since the CNIs require deeper
-access on the host machine's kernel.
+As they develop and mature, CNIs such as [cilium][] and [calico][] more frequently require
+specific kernel features which make them more difficult to operate from within the
+confinement of LXD. **Charmed Kubernetes** makes a best effort to operate CNIs, but admins
+should consider avoiding LXD as a choice to operate `kubernetes-worker` or 
+`kubernetes-control-plane` since the CNIs require deeper access on the host machine's kernel.
 
 If the choice is made to continue using LXD for nodes where a CNI is deployed, the LXD profile must be opened
-up for those lxd units to adjust the host machine's kernel space. Consider a deployment where [calico][] is deployed
-as a subordinate unit of `kubernetes-control-plane` on a LXD. Those LXDs exist solely on machines where the primary 
+up for those units to adjust the host machine's kernel space. Consider a deployment where [calico][] is deployed
+as a subordinate unit of `kubernetes-control-plane` on LXD. Those LXDs exist solely on machines where the primary 
 app is `ubuntu-control-plane-nodes` with the `ubuntu` charm.
 
 Both CNIs require access to the host `/sys/fs/bpf` and this can be exposed through the following profile adjustment
@@ -73,8 +75,11 @@ devices:
     source: /sys/fs/bpf
     type: disk
 EOF'
+```
 
-# Restart every container in the machine to update it's profile
+Every container in the machine should then be restarted to update its profile:
+
+```bash
 readarray units < <(juju status $machine_app --format yaml | yq ".applications.$machine_app.units | keys" )
 for unit in "${units[@]}"; do
     juju exec -u $(echo $unit | yq .[0]) -- 'sudo lxc restart --all'

--- a/pages/k8s/cni-overview.md
+++ b/pages/k8s/cni-overview.md
@@ -36,7 +36,7 @@ The currently supported base CNI solutions for **Charmed Kubernetes** are:
  -   [Kube-OVN][kube-ovn]
  -   [Tigera Secure EE][tigera]
 
-By default, **Charmed Kubernetes** will deploy the cluster using Calico. To chose
+By default, **Charmed Kubernetes** will deploy the cluster using Calico. To choose
 a different CNI provider, see the individual links above.
 
 The following CNI addons are also available:

--- a/pages/k8s/install-local.md
+++ b/pages/k8s/install-local.md
@@ -174,6 +174,15 @@ You may need to start a new shell (or logout and login) for this to take effect:
 newgrp lxd
 ```
 
+### Confirm CNIs do not need specific kernel parameters unsupported by the lxd-profile
+
+If the CNI pods fail to start, see notes on the specific CNI page.
+
+CNIs like [Cilium][cilium] and [Calico][calico] need access to `/sys/fs/bpf`, but that
+mountpoint is not supported by the juju's [validation check][juju-validation-check] 
+for the charm specific `lxd-profile.yaml`. See [CNI Overview][cni-overview] for more
+details.
+
 ### Services fail to start with errors related to missing files in the /proc filesystem
 
 For example, `systemctl status snap.kube-proxy.daemon` may report the following:
@@ -249,6 +258,10 @@ juju config calico ignore-loose-rpf=true
 
 [lxd-home]: https://ubuntu.com/lxd
 [lxd-profile]: https://github.com/charmed-kubernetes/charm-kubernetes-worker/blob/main/lxd-profile.yaml
+[calico]: /kubernetes/docs/cni-calico
+[cilium]: /kubernetes/docs/cni-cilium
+[cni-overview]: /kubernetes/docs/cni-overview
+[juju-validation-check]: https://juju.is/docs/juju/use-lxd-profiles
 [Juju]: https://jaas.ai
 [snap]: https://snapcraft.io/docs/installing-snapd
 [install]: /kubernetes/docs/install-manual


### PR DESCRIPTION
Adjust docs to show how to adjust lxd profiles to expose `/sys/fs/bpf`.  Juju team has accurately warned that exposing more of the host machine's kernel to lxd adjustments will just yield future confusion and it's likely we should adviser users to not deploy CNI's that require these kernel params on LXD.

Doc mitigation for [LP:2034448](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2034448)