### PR TITLE
Prepare release notes for 1.28 -> 1.31

### DIFF
--- a/pages/k8s/1.28/release-notes.md
+++ b/pages/k8s/1.28/release-notes.md
@@ -13,6 +13,15 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+# 1.28+ck3
+
+### Mar 31, 2025 - `charmed-kubernetes --channel 1.28/stable`
+
+## Notable Fixes
+
+### Kubernetes Worker Charm
+* [LP#2104056](https://bugs.launchpad.net/bugs/2104056) Update ingress-nginx to 1.11.5 resolving CVE-2025-1974
+
 
 ## 1.28+ck2 Bugfix release
 

--- a/pages/k8s/1.29/release-notes.md
+++ b/pages/k8s/1.29/release-notes.md
@@ -13,6 +13,15 @@ layout: [base, ubuntu-com]
 toc: false
 ---
 
+# 1.29+ck5
+
+### Mar 31, 2025 - `charmed-kubernetes --channel 1.29/stable`
+
+## Notable Fixes
+
+### Kubernetes Worker Charm
+* [LP#2104056](https://bugs.launchpad.net/bugs/2104056) Update ingress-nginx to 1.11.5 resolving CVE-2025-1974
+
 # 1.29+ck4
 
 ### Jul 31, 2024 - `charmed-kubernetes --channel 1.29/stable`

--- a/pages/k8s/1.30/release-notes.md
+++ b/pages/k8s/1.30/release-notes.md
@@ -17,6 +17,15 @@ toc: false
 
 ---
 
+# 1.30+ck2
+
+### Mar 31, 2025 - `charmed-kubernetes --channel 1.30/stable`
+
+## Notable Fixes
+
+### Kubernetes Worker Charm
+* [LP#2104056](https://bugs.launchpad.net/bugs/2104056) Update ingress-nginx to 1.11.5 resolving CVE-2025-1974
+
 # 1.30+ck1
 
 ### Jul 31, 2024 - `charmed-kubernetes --channel 1.30/stable`

--- a/pages/k8s/1.31/release-notes.md
+++ b/pages/k8s/1.31/release-notes.md
@@ -17,6 +17,15 @@ toc: False
 
 ---
 
+# 1.31+ck2
+
+### Mar 31, 2025 - `charmed-kubernetes --channel 1.31/stable`
+
+## Notable Fixes
+
+### Kubernetes Worker Charm
+* [LP#2104056](https://bugs.launchpad.net/bugs/2104056) Update ingress-nginx to 1.11.5 resolving CVE-2025-1974
+
 # 1.31+ck1
 
 ### Dec 16, 2024 - `charmed-kubernetes --channel 1.31/stable`

--- a/pages/k8s/release-notes.md
+++ b/pages/k8s/release-notes.md
@@ -12,9 +12,46 @@ permalink: release-notes.html
 layout: [base, ubuntu-com]
 toc: False
 ---
+
 # 1.32+ck1
 
 ### Mar 28, 2025 - `charmed-kubernetes --channel 1.32/stable`
+
+## Notable Fixes
+
+### Kubernetes Worker Charm
+* [LP#2104056](https://bugs.launchpad.net/bugs/2104056) Update ingress-nginx to 1.11.5 resolving CVE-2025-1974
+
+# 1.31+ck2
+
+### Mar 31, 2025 - `charmed-kubernetes --channel 1.31/stable`
+
+## Notable Fixes
+
+### Kubernetes Worker Charm
+* [LP#2104056](https://bugs.launchpad.net/bugs/2104056) Update ingress-nginx to 1.11.5 resolving CVE-2025-1974
+
+# 1.30+ck2
+
+### Mar 31, 2025 - `charmed-kubernetes --channel 1.30/stable`
+
+## Notable Fixes
+
+### Kubernetes Worker Charm
+* [LP#2104056](https://bugs.launchpad.net/bugs/2104056) Update ingress-nginx to 1.11.5 resolving CVE-2025-1974
+
+# 1.29+ck5
+
+### Mar 31, 2025 - `charmed-kubernetes --channel 1.29/stable`
+
+## Notable Fixes
+
+### Kubernetes Worker Charm
+* [LP#2104056](https://bugs.launchpad.net/bugs/2104056) Update ingress-nginx to 1.11.5 resolving CVE-2025-1974
+
+# 1.28+ck3
+
+### Mar 31, 2025 - `charmed-kubernetes --channel 1.28/stable`
 
 ## Notable Fixes
 

--- a/pages/k8s/release-notes.md
+++ b/pages/k8s/release-notes.md
@@ -17,41 +17,11 @@ toc: False
 
 ### Mar 28, 2025 - `charmed-kubernetes --channel 1.32/stable`
 
-## Notable Fixes
-
-### Kubernetes Worker Charm
-* [LP#2104056](https://bugs.launchpad.net/bugs/2104056) Update ingress-nginx to 1.11.5 resolving CVE-2025-1974
-
-# 1.31+ck2
-
-### Mar 31, 2025 - `charmed-kubernetes --channel 1.31/stable`
-
-## Notable Fixes
-
-### Kubernetes Worker Charm
-* [LP#2104056](https://bugs.launchpad.net/bugs/2104056) Update ingress-nginx to 1.11.5 resolving CVE-2025-1974
-
-# 1.30+ck2
-
-### Mar 31, 2025 - `charmed-kubernetes --channel 1.30/stable`
-
-## Notable Fixes
-
-### Kubernetes Worker Charm
-* [LP#2104056](https://bugs.launchpad.net/bugs/2104056) Update ingress-nginx to 1.11.5 resolving CVE-2025-1974
-
-# 1.29+ck5
-
-### Mar 31, 2025 - `charmed-kubernetes --channel 1.29/stable`
-
-## Notable Fixes
-
-### Kubernetes Worker Charm
-* [LP#2104056](https://bugs.launchpad.net/bugs/2104056) Update ingress-nginx to 1.11.5 resolving CVE-2025-1974
-
-# 1.28+ck3
-
-### Mar 31, 2025 - `charmed-kubernetes --channel 1.28/stable`
+### Backports on Mar 31, 2025
+* **1.31+ck2** - `charmed-kubernetes --channel 1.31/stable`
+* **1.30+ck2** - `charmed-kubernetes --channel 1.30/stable`
+* **1.29+ck5** - `charmed-kubernetes --channel 1.29/stable`
+* **1.28+ck3** - `charmed-kubernetes --channel 1.28/stable`
 
 ## Notable Fixes
 


### PR DESCRIPTION
Adding release notes for `CVE-2025-1974` backports