### PR TITLE
Ensure tokens integration when setting up cos

### DIFF
--- a/pages/k8s/how-to-cos-lite.md
+++ b/pages/k8s/how-to-cos-lite.md
@@ -96,11 +96,13 @@ you can run `juju models` to see a list of available models):
 juju switch <charmed-kubernetes-model>
 ```
 
-Ensure `tokens` is related to all worker applications
+Ensure `tokens` relation between `kubernetes-worker` and
+`kubernetes-control-plane` applications exist. This grants the `grafana-agent`
+on the worker nodes access to metrics from the node's `kubelet`. Repeat the
+following command for every application of the charm type `kubernetes-worker`.
 
 ```
 juju integrate kubernetes-control-plane:tokens kubernetes-worker
-... repeat for other worker applications
 ```
 
 Consume the COS Lite endpoints:


### PR DESCRIPTION
### Overview
Adds instructions for installing cos-lite with charmed kubernetes

### Details
* ensure the `tokens` relation is enabled