### PR TITLE
Document changes of the 1.33+ck1 release

### DIFF
--- a/pages/k8s/1.33/release-notes.md
+++ b/pages/k8s/1.33/release-notes.md
@@ -17,6 +17,24 @@ layout:
 toc: False
 ---
 
+# 1.33+ck1
+
+### July 8, 2025 - `charmed-kubernetes --channel 1.33/stable`
+
+## Notable Fixes
+
+### What's new
+
+The following charms can now control whether or not they ignore juju's model
+config `juju-*-proxy` based on the charm config `web-proxy-enable` on each charm.
+* `openstack-integrator`
+* `openstack-cloud-controller`
+* `cinder-csi`
+
+### Openstack Integrator
+* [LP#2110221](https://launchpad.net/bugs/2110221) Adjustment to charm config or
+cloud credentials will trigger a relation changed events on the `openstack` interface.
+
 # 1.33
 
 ### June 23, 2025 - `charmed-kubernetes --channel 1.33/stable`

--- a/pages/k8s/release-notes.md
+++ b/pages/k8s/release-notes.md
@@ -13,6 +13,24 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+# 1.33+ck1
+
+### July 8, 2025 - `charmed-kubernetes --channel 1.33/stable`
+
+## Notable Fixes
+
+### What's new
+
+The following charms can now control whether or not they ignore juju's model
+config `juju-*-proxy` based on the charm config `web-proxy-enable` on each charm.
+* `openstack-integrator`
+* `openstack-cloud-controller`
+* `cinder-csi`
+
+### Openstack Integrator
+* [LP#2110221](https://launchpad.net/bugs/2110221) Adjustment to charm config or
+cloud credentials will trigger a relation changed events on the `openstack` interface.
+
 # 1.33
 
 ### June 23, 2025 - `charmed-kubernetes --channel 1.33/stable`


### PR DESCRIPTION
### Overview
Detail changes and bugfixes present in the Charmed Kubernetes 1.33+ck1 release.

### Details
* bug fix for openstack-integrator
* feature change (`web-proxy-enable`) for various openstack charms