### PR TITLE
docs: prepare bugfix release notes for `1.31`, `1.32`, and `1.33`

### DIFF
--- a/pages/k8s/1.31/release-notes.md
+++ b/pages/k8s/1.31/release-notes.md
@@ -24,11 +24,11 @@ toc: False
 ## Notable Fixes
 
 ### Kubernetes Control Plane Charm
-* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) Fetch `kube-control` address bindings
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614) Fetch `kube-control` address bindings
 and include them in the Subject Alternative Names (SANs).
 
 ### Kubernetes Worker Charm
-* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) Fetch `kube-control` address bindings
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614) Fetch `kube-control` address bindings
 and include them in the Subject Alternative Names (SANs).
 
 # 1.31+ck3

--- a/pages/k8s/1.31/release-notes.md
+++ b/pages/k8s/1.31/release-notes.md
@@ -17,6 +17,20 @@ toc: False
 
 ---
 
+# 1.31+ck4
+
+### August 6, 2025 - `charmed-kubernetes --channel 1.33/stable`
+
+## Notable Fixes
+
+### Kubernetes Control Plane Charm
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) Fetch `kube-control` address bindings
+and include them in the Subject Alternative Names (SANs).
+
+### Kubernetes Worker Charm
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) Fetch `kube-control` address bindings
+and include them in the Subject Alternative Names (SANs).
+
 # 1.31+ck3
 
 ### May 8, 2025 - `charmed-kubernetes --channel 1.31/stable`

--- a/pages/k8s/1.31/release-notes.md
+++ b/pages/k8s/1.31/release-notes.md
@@ -19,7 +19,7 @@ toc: False
 
 # 1.31+ck4
 
-### August 6, 2025 - `charmed-kubernetes --channel 1.33/stable`
+### August 6, 2025 - `charmed-kubernetes --channel 1.31/stable`
 
 ## Notable Fixes
 

--- a/pages/k8s/1.32/release-notes.md
+++ b/pages/k8s/1.32/release-notes.md
@@ -17,6 +17,20 @@ layout:
 toc: False
 ---
 
+# 1.32+ck3
+
+### August 6, 2025 - `charmed-kubernetes --channel 1.33/stable`
+
+## Notable Fixes
+
+### Kubernetes Control Plane Charm
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) Fetch `kube-control` address bindings
+and include them in the Subject Alternative Names (SANs).
+
+### Kubernetes Worker Charm
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) Fetch `kube-control` address bindings
+and include them in the Subject Alternative Names (SANs).
+
 # 1.32+ck2
 
 ### May 8, 2025 - `charmed-kubernetes --channel 1.32/stable`

--- a/pages/k8s/1.32/release-notes.md
+++ b/pages/k8s/1.32/release-notes.md
@@ -24,11 +24,11 @@ toc: False
 ## Notable Fixes
 
 ### Kubernetes Control Plane Charm
-* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) Fetch `kube-control` address bindings
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614) Fetch `kube-control` address bindings
 and include them in the Subject Alternative Names (SANs).
 
 ### Kubernetes Worker Charm
-* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) Fetch `kube-control` address bindings
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614) Fetch `kube-control` address bindings
 and include them in the Subject Alternative Names (SANs).
 
 # 1.32+ck2

--- a/pages/k8s/1.32/release-notes.md
+++ b/pages/k8s/1.32/release-notes.md
@@ -19,7 +19,7 @@ toc: False
 
 # 1.32+ck3
 
-### August 6, 2025 - `charmed-kubernetes --channel 1.33/stable`
+### August 6, 2025 - `charmed-kubernetes --channel 1.32/stable`
 
 ## Notable Fixes
 

--- a/pages/k8s/1.33/release-notes.md
+++ b/pages/k8s/1.33/release-notes.md
@@ -25,11 +25,11 @@ toc: False
 ## Notable Fixes
 
 ### Kubernetes Control Plane Charm
-* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) Fetch `kube-control` address bindings
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614) Fetch `kube-control` address bindings
 and include them in the Subject Alternative Names (SANs).
 
 ### Kubernetes Worker Charm
-* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) Fetch `kube-control` address bindings
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614) Fetch `kube-control` address bindings
 and include them in the Subject Alternative Names (SANs).
 
 # 1.33+ck1

--- a/pages/k8s/1.33/release-notes.md
+++ b/pages/k8s/1.33/release-notes.md
@@ -18,6 +18,20 @@ toc: False
 
 ---
 
+# 1.33+ck2
+
+### August 6, 2025 - `charmed-kubernetes --channel 1.33/stable`
+
+## Notable Fixes
+
+### Kubernetes Control Plane Charm
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) Fetch `kube-control` address bindings
+and include them in the Subject Alternative Names (SANs).
+
+### Kubernetes Worker Charm
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) Fetch `kube-control` address bindings
+and include them in the Subject Alternative Names (SANs).
+
 # 1.33+ck1
 
 ### July 8, 2025 - `charmed-kubernetes --channel 1.33/stable`

--- a/pages/k8s/release-notes.md
+++ b/pages/k8s/release-notes.md
@@ -20,11 +20,11 @@ toc: False
 ## Notable Fixes
 
 ### Kubernetes Control Plane Charm
-* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) Fetch `kube-control` address bindings
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614) Fetch `kube-control` address bindings
 and include them in the Subject Alternative Names (SANs).
 
 ### Kubernetes Worker Charm
-* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) Fetch `kube-control` address bindings
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614) Fetch `kube-control` address bindings
 and include them in the Subject Alternative Names (SANs).
 
 # 1.33+ck1
@@ -135,11 +135,11 @@ relevant sections of the [upstream release notes][upstream-changelog-1.33].
 ## Notable Fixes
 
 ### Kubernetes Control Plane Charm
-* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) Fetch `kube-control` address bindings
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614) Fetch `kube-control` address bindings
 and include them in the Subject Alternative Names (SANs).
 
 ### Kubernetes Worker Charm
-* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) Fetch `kube-control` address bindings
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614) Fetch `kube-control` address bindings
 and include them in the Subject Alternative Names (SANs).
 
 # 1.32+ck2
@@ -283,11 +283,11 @@ please see the relevant sections of the
 ## Notable Fixes
 
 ### Kubernetes Control Plane Charm
-* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) Fetch `kube-control` address bindings
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614) Fetch `kube-control` address bindings
 and include them in the Subject Alternative Names (SANs).
 
 ### Kubernetes Worker Charm
-* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) Fetch `kube-control` address bindings
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614) Fetch `kube-control` address bindings
 and include them in the Subject Alternative Names (SANs).
 
 # 1.31+ck3

--- a/pages/k8s/release-notes.md
+++ b/pages/k8s/release-notes.md
@@ -130,7 +130,7 @@ relevant sections of the [upstream release notes][upstream-changelog-1.33].
 
 # 1.32+ck3
 
-### August 6, 2025 - `charmed-kubernetes --channel 1.33/stable`
+### August 6, 2025 - `charmed-kubernetes --channel 1.32/stable`
 
 ## Notable Fixes
 
@@ -278,7 +278,7 @@ please see the relevant sections of the
 
 # 1.31+ck4
 
-### August 6, 2025 - `charmed-kubernetes --channel 1.33/stable`
+### August 6, 2025 - `charmed-kubernetes --channel 1.31/stable`
 
 ## Notable Fixes
 

--- a/pages/k8s/release-notes.md
+++ b/pages/k8s/release-notes.md
@@ -13,6 +13,20 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+# 1.33+ck2
+
+### August 6, 2025 - `charmed-kubernetes --channel 1.33/stable`
+
+## Notable Fixes
+
+### Kubernetes Control Plane Charm
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) Fetch `kube-control` address bindings
+and include them in the Subject Alternative Names (SANs).
+
+### Kubernetes Worker Charm
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) Fetch `kube-control` address bindings
+and include them in the Subject Alternative Names (SANs).
+
 # 1.33+ck1
 
 ### July 8, 2025 - `charmed-kubernetes --channel 1.33/stable`
@@ -114,6 +128,19 @@ relevant sections of the [upstream release notes][upstream-changelog-1.33].
 
 [upstream-changelog-1.33]: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#deprecation
 
+# 1.32+ck3
+
+### August 6, 2025 - `charmed-kubernetes --channel 1.33/stable`
+
+## Notable Fixes
+
+### Kubernetes Control Plane Charm
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) Fetch `kube-control` address bindings
+and include them in the Subject Alternative Names (SANs).
+
+### Kubernetes Worker Charm
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) Fetch `kube-control` address bindings
+and include them in the Subject Alternative Names (SANs).
 
 # 1.32+ck2
 
@@ -248,6 +275,20 @@ please see the relevant sections of the
 <!--LINKS-->
 
 [rel]: /kubernetes/docs/release-notes
+
+# 1.31+ck4
+
+### August 6, 2025 - `charmed-kubernetes --channel 1.33/stable`
+
+## Notable Fixes
+
+### Kubernetes Control Plane Charm
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) Fetch `kube-control` address bindings
+and include them in the Subject Alternative Names (SANs).
+
+### Kubernetes Worker Charm
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) Fetch `kube-control` address bindings
+and include them in the Subject Alternative Names (SANs).
 
 # 1.31+ck3
 


### PR DESCRIPTION
## Overview
Add release notes for `1.33+ck2`, `1.32+ck3`, and `1.31+ck4`.